### PR TITLE
Testing fix for JS

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,19 +8,24 @@ parserOptions:
 rules:
   no-unused-vars: off
   require-jsdoc: off
-  indent:
-    - error
-    - 2
-    - SwitchCase: 1
-      MemberExpression: 2
-      FunctionDeclaration:
-        body: 1
-        parameters: 2
-      FunctionExpression:
-        body: 1
-        parameters: 2
-      CallExpression:
-        - arguments: 2
+  indent: [
+    "error", 2,  # Google use 2-space indents
+    # Google uses +4 space indents for line continuations.
+    {
+        "SwitchCase": 1,
+        "MemberExpression": 2,
+        "FunctionDeclaration": {
+            "body": 1,
+            "parameters": 2
+        },
+        "FunctionExpression": {
+            "body": 1,
+            "parameters": 2
+        },
+        "CallExpression": {
+            "arguments": 2
+        },
         # Ignore default rules for ternary expressions.
-      ignoredNodes:
-        'ConditionalExpression'
+        "ignoredNodes": ["ConditionalExpression"]
+    }
+  ]

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,3 +8,19 @@ parserOptions:
 rules:
   no-unused-vars: 'off'
   require-jsdoc: 'off'
+  indent:
+    - 2  # Google use 2-space indents
+    # Google uses +4 space indents for line continuations.
+    - SwitchCase: 1,
+    - MemberExpression: 2,
+    - FunctionDeclaration:
+            - body: 1,
+            - parameters: 2
+        FunctionExpression:
+            - body: 1,
+            - parameters: 2
+    - CallExpression:
+        - arguments: 2
+        # Ignore default rules for ternary expressions.
+    - ignoredNodes:
+      - 'ConditionalExpression'

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -9,21 +9,20 @@ rules:
   no-unused-vars: off
   require-jsdoc: off
   indent: [
-    "error", 2,  # Google use 2-space indents
-    # Google uses +4 space indents for line continuations.
+    "error", 2,
     {
         "SwitchCase": 1,
-        "MemberExpression": "off",
+        "MemberExpression": 0,
         "FunctionDeclaration": {
             "body": 1,
-            "parameters": "off"
+            "parameters": 0
         },
         "FunctionExpression": {
-            "body": "off",
+            "body": 0,
             "parameters": 2
         },
         "CallExpression": {
-            "arguments": "off"
+            "arguments": 0
         },
         # Ignore default rules for ternary expressions.
         "ignoredNodes": ["ConditionalExpression"]

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,26 +1,26 @@
 env:
   browser: true
   es2020: true
-extends: 'google'
+extends: google
 parserOptions:
   ecmaVersion: 11
   sourceType: module
 rules:
-  no-unused-vars: 'off'
-  require-jsdoc: 'off'
+  no-unused-vars: off
+  require-jsdoc: off
   indent:
-    - 2  # Google use 2-space indents
-    # Google uses +4 space indents for line continuations.
-    - SwitchCase: 1,
-    - MemberExpression: 2,
-    - FunctionDeclaration:
-            - body: 1,
-            - parameters: 2
-        FunctionExpression:
-            - body: 1,
-            - parameters: 2
-    - CallExpression:
+    - error
+    - 2
+    - SwitchCase: 1
+      MemberExpression: 2
+      FunctionDeclaration:
+        body: 1
+        parameters: 2
+      FunctionExpression:
+        body: 1
+        parameters: 2
+      CallExpression:
         - arguments: 2
         # Ignore default rules for ternary expressions.
-    - ignoredNodes:
-      - 'ConditionalExpression'
+      ignoredNodes:
+        'ConditionalExpression'

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,23 +8,4 @@ parserOptions:
 rules:
   no-unused-vars: off
   require-jsdoc: off
-  indent: [
-    "error", 2,
-    {
-        "SwitchCase": 1,
-        "MemberExpression": 0,
-        "FunctionDeclaration": {
-            "body": 1,
-            "parameters": 0
-        },
-        "FunctionExpression": {
-            "body": 0,
-            "parameters": 2
-        },
-        "CallExpression": {
-            "arguments": 0
-        },
-        # Ignore default rules for ternary expressions.
-        "ignoredNodes": ["ConditionalExpression"]
-    }
-  ]
+  indent: off

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -13,17 +13,17 @@ rules:
     # Google uses +4 space indents for line continuations.
     {
         "SwitchCase": 1,
-        "MemberExpression": 2,
+        "MemberExpression": "off"
         "FunctionDeclaration": {
             "body": 1,
-            "parameters": 2
+            "parameters": "off"
         },
         "FunctionExpression": {
-            "body": 1,
+            "body": "off",
             "parameters": 2
         },
         "CallExpression": {
-            "arguments": 2
+            "arguments": "off"
         },
         # Ignore default rules for ternary expressions.
         "ignoredNodes": ["ConditionalExpression"]

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -13,7 +13,7 @@ rules:
     # Google uses +4 space indents for line continuations.
     {
         "SwitchCase": 1,
-        "MemberExpression": "off"
+        "MemberExpression": "off",
         "FunctionDeclaration": {
             "body": 1,
             "parameters": "off"

--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -19,8 +19,9 @@ jobs:
         run: |
           for file in $(git diff --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(java)$"); do
             echo -e "Running google-java-format on:\n $file\n"
-            echo -e "Corrected file will be printed below if formatting errors found\n"
+            echo -e "Diff output followed by corrected file will be printed below if formatting errors found\n"
             if ! java -jar ./google-java-format-1.8-all-deps.jar $file | diff $file -; then
+              echo -e "\n"
               java -jar ./google-java-format-1.8-all-deps.jar $file
               EXIT=1
             fi

--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -19,7 +19,7 @@ jobs:
         run: |
           for file in $(git diff --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(java)$"); do
             echo -e "Running google-java-format on:\n $file\n"
-            if ! java -jar ./google-java-format-1.8-all-deps.jar $file | cat -; then
+            if ! java -jar ./google-java-format-1.8-all-deps.jar $file | diff $file (cat -); then
               EXIT=1
             fi
             echo ""

--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -20,7 +20,8 @@ jobs:
           for file in $(git diff --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(java)$"); do
             echo -e "Running google-java-format on:\n $file\n"
             echo -e "Corrected file will be printed below if formatting errors found\n"
-            if java -jar ./google-java-format-1.8-all-deps.jar $file > correctedJavaFormat | diff $file correctedJavaFormat; then
+            if ! java -jar ./google-java-format-1.8-all-deps.jar $file | diff $file -; then
+              java -jar ./google-java-format-1.8-all-deps.jar $file
               EXIT=1
             fi
             echo ""

--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -19,7 +19,7 @@ jobs:
         run: |
           for file in $(git diff --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(java)$"); do
             echo -e "Running google-java-format on:\n $file\n"
-            echo -e "Corrected file will be printed below if formatting errors found."
+            echo -e "Corrected file will be printed below if formatting errors found\n"
             if java -jar ./google-java-format-1.8-all-deps.jar $file; then
               EXIT=1
             fi

--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -19,8 +19,7 @@ jobs:
         run: |
           for file in $(git diff --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(java)$"); do
             echo -e "Running google-java-format on:\n $file\n"
-            if ! java -jar ./google-java-format-1.8-all-deps.jar $file | diff $file -; then
-              cat -
+            if ! java -jar ./google-java-format-1.8-all-deps.jar $file | cat | diff $file -; then
               EXIT=1
             fi
             echo ""

--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -20,7 +20,7 @@ jobs:
           for file in $(git diff --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(java)$"); do
             echo -e "Running google-java-format on:\n $file\n"
             echo -e "Corrected file will be printed below if formatting errors found\n"
-            if java -jar ./google-java-format-1.8-all-deps.jar $file; then
+            if java -jar ./google-java-format-1.8-all-deps.jar $file > correctedJavaFormat | diff $file correctedJavaFormat; then
               EXIT=1
             fi
             echo ""

--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -19,7 +19,8 @@ jobs:
         run: |
           for file in $(git diff --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(java)$"); do
             echo -e "Running google-java-format on:\n $file\n"
-            if ! java -jar ./google-java-format-1.8-all-deps.jar $file | diff $file (cat -); then
+            if ! java -jar ./google-java-format-1.8-all-deps.jar $file | diff $file -; then
+              cat -
               EXIT=1
             fi
             echo ""

--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -19,7 +19,7 @@ jobs:
         run: |
           for file in $(git diff --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(java)$"); do
             echo -e "Running google-java-format on:\n $file\n"
-            if ! java -jar ./google-java-format-1.8-all-deps.jar $file | cat - > $file; then
+            if ! java -jar ./google-java-format-1.8-all-deps.jar $file | cat -; then
               EXIT=1
             fi
             echo ""

--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -19,7 +19,7 @@ jobs:
         run: |
           for file in $(git diff --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(java)$"); do
             echo -e "Running google-java-format on:\n $file\n"
-            if ! java -jar ./google-java-format-1.8-all-deps.jar $file | cat | diff $file -; then
+            if ! java -jar ./google-java-format-1.8-all-deps.jar $file | cat - | diff $file -; then
               EXIT=1
             fi
             echo ""

--- a/.github/workflows/javalint.yaml
+++ b/.github/workflows/javalint.yaml
@@ -19,7 +19,7 @@ jobs:
         run: |
           for file in $(git diff --name-only origin/master HEAD -- . ':!node_modules' | grep -E "(.*)\.(java)$"); do
             echo -e "Running google-java-format on:\n $file\n"
-            if ! java -jar ./google-java-format-1.8-all-deps.jar $file | diff $file -; then
+            if ! java -jar ./google-java-format-1.8-all-deps.jar $file | cat - > $file; then
               EXIT=1
             fi
             echo ""

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -37,7 +37,7 @@ public class QueryServlet extends HttpServlet {
     String location = request.getParameter("location");
   
     if (!queryToDataRow.containsKey(action)
-        || !queryToDataRow.get(action).containsKey(personType)) {
+        || !queryToDataRow.get(action).containsKey(personType)) { 
       // We don't have a data table for this query
       response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
       return;

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -1,5 +1,5 @@
-import com.google.gson.Gson;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -1,55 +1,50 @@
-import java.io.IOException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import com.google.gson.Gson;
 import com.google.common.collect.ImmutableMap;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.stream.Stream;
-import java.util.stream.Collectors;
-import java.net.HttpURLConnection;
-import java.net.URL;
+import com.google.gson.Gson;
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /** Servlet that handles census queries from users */
 @WebServlet("/query")
 public class QueryServlet extends HttpServlet {
 
   // Hardcoded initial choices for which lines of the data table are accessed
-  Map<String, Map<String, String>> queryToDataRow = 
-  ImmutableMap.of(
-      "live", ImmutableMap.of("under-18", "023E", "over-18", "026E", "all-ages", "001E"),
-      "work", ImmutableMap.of("over-18", "154E,S0201_157E"),
-     "moved", ImmutableMap.of("all-ages", "119E,S0201_126E"));
+  Map<String, Map<String, String>> queryToDataRow =
+      ImmutableMap.of(
+          "live",
+          ImmutableMap.of("under-18", "023E", "over-18", "026E", "all-ages", "001E"),
+          "work",
+          ImmutableMap.of("over-18", "154E,S0201_157E"),
+          "moved",
+          ImmutableMap.of("all-ages", "119E,S0201_126E"));
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String personType = request.getParameter("person-type");
     String action = request.getParameter("action");
     String location = request.getParameter("location");
-  
+
     if (!queryToDataRow.containsKey(action)
-        || !queryToDataRow.get(action).containsKey(personType)) { 
+        || !queryToDataRow.get(action).containsKey(personType)) {
       // We don't have a data table for this query
       response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
       return;
     }
 
-    URL fetchUrl = 
-      new URL(
-        "https://api.census.gov/data/2018/acs/acs1/spp?get=NAME,S0201_" 
-          + queryToDataRow.get(action).get(personType)
-          + "&for=" 
-          + location 
-          + ":*&key=ea65020114ffc1e71e760341a0285f99e73eabbc");
+    URL fetchUrl =
+        new URL(
+            "https://api.census.gov/data/2018/acs/acs1/spp?get=NAME,S0201_"
+                + queryToDataRow.get(action).get(personType)
+                + "&for="
+                + location
+                + ":*&key=ea65020114ffc1e71e760341a0285f99e73eabbc");
 
     HttpURLConnection connection = (HttpURLConnection) fetchUrl.openConnection();
     connection.setRequestMethod("GET");

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -1,5 +1,5 @@
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
+import com.google.common.collect.ImmutableMap;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -19,69 +19,75 @@ google.charts.load('current', {
 });
 
 function passQuery() {
-  document.getElementById('result').style.display = 'block';
+  const information = document.getElementById('more-info');
+  information.innerText = 'Please wait. Loading...';
   const query = new FormData(document.getElementById('query-form'));
   const personType = query.get('person-type');
+  const action = query.get('action');
   const location = query.get('location');
 
-  fetch('/query?person-type=' + personType + '&location=' + location)
-      .then((response) => {
-        if (response.ok) {
-          response.json().then((jsonResponse) => JSON.parse(jsonResponse))
-              .then((data) => {
-                // data is a 2D array, where the first row is a header row and all
-                // subsequent rows are one piece of data (e.g. for a state or county)
-                displayVisualization(data);
-              });
-        } else {
-          console.log('There was an error');
-        }
-      });
+  const fetchUrl = '/query?person-type=' + personType +
+      '&action=' + action +
+      '&location=' + location;
+  
+  fetch(fetchUrl)
+    .then((response) => {
+      if (response.ok) {
+        response.json().then((jsonResponse) => JSON.parse(jsonResponse))
+        .then((data) => {
+          // data is a 2D array, where the first row is a header row and all
+          // subsequent rows are one piece of data (e.g. for a state or county)
+          information.innerText = '';
+          displayVisualization(data);
+        });
+      } else {
+        console.log(
+          `An error occurred: ${response.status}: ${response.statusText}`);
+      }
+    });
 }
 
-// displayVisualization takes in a data array representing the 2D array returned by the
-// census API. The function creates the necessary visualization with the census data.
+// displayVisualization takes in a data array representing the 2D array
+// returned  by the census API. The first row in the census Data array
+// is the header, which describes the type of data.
+// Eg: Header for the query that finds for populations of all counties is
+// ["NAME","S0201_001E","state","county"]
 function displayVisualization(censusDataArray) {
   if (censusDataArray[0][2] == 'state' && censusDataArray[0][3] != 'county') {
     google.charts.setOnLoadCallback(drawRegionsMap(censusDataArray));
   } else {
     // We currently do not have counties implemented
+    const errorMessage = 'We do not support this visualization yet';
     document.getElementById('map').innerHTML = '';
-    document.getElementById('more-info').innerHTML = 'We do not have this information yet.';
+    document.getElementById('more-info').innerHTML = errorMessage;
   }
 }
 
-// Takes in a 2D array from the census API and draws the appropriate visualization
+// Takes in a 2D array from the census API and displays the visualization
 function drawRegionsMap(censusDataArray) {
   const shortDataArray = createDataArray(censusDataArray);
   const data = google.visualization.arrayToDataTable(shortDataArray);
   const options = {
-    colorAxis: {colors: ['white', 'blue']},
-    height: 550,
-    region: 'US',
-    resolution: 'provinces',
+    'region': 'US',
+    'resolution': 'provinces',
+    'colorAxis': {colors: ['white', 'blue']},
   };
-  document.getElementById('result').style.display = 'block';
-  const chart = new google.visualization.GeoChart(document.getElementById('map'));
+  const mapElement = document.getElementById('map');
+  const chart = new google.visualization.GeoChart(mapElement);
   chart.draw(data, options);
-  document.getElementById('more-info').innerHTML =
-      'These populations are divided by 1000';
+  const mapNote = 'Populations are in thousands';
+  document.getElementById('more-info').innerHTML = mapNote;
 }
 
-// createDataArray takes in the data array returned by the census API and reformats it
-// into a data table that can be processed by the visualization API.
+// createDataArray takes in the data array returned by the census API
+// and reformats it into a data table for the visualization API.
 function createDataArray(censusDataArray) {
   const vizDataArray = [];
   censusDataArray.forEach((state) => {
     vizDataArray.push([state[0], state[1]/1000]);
   });
+  // Changes the header of the vizDataArray to match the Visualization API
   vizDataArray[0][0] = 'State';
   vizDataArray[0][1] = 'Population';
   return vizDataArray;
 }
-
-function resizeVisualization() {
-  passQuery();
-}
-
-window.addEventListener('resize', resizeVisualization);

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -19,7 +19,7 @@ google.charts.load('current', {
 });
 
 function passQuery() {
-  const information = document.getElementById('more-info');
+ const information = document.getElementById('more-info');
   information.innerText = 'Please wait. Loading...';
   const query = new FormData(document.getElementById('query-form'));
   const personType = query.get('person-type');

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -30,7 +30,7 @@ function passQuery() {
       '&action=' + action +
       '&location=' + location;
   
-  fetch(fetchUrl)
+  fetch(fetchUrl) 
     .then((response) => {
       if (response.ok) {
         response.json().then((jsonResponse) => JSON.parse(jsonResponse))

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -19,75 +19,69 @@ google.charts.load('current', {
 });
 
 function passQuery() {
- const information = document.getElementById('more-info');
-  information.innerText = 'Please wait. Loading...';
+  document.getElementById('result').style.display = 'block';
   const query = new FormData(document.getElementById('query-form'));
   const personType = query.get('person-type');
-  const action = query.get('action');
   const location = query.get('location');
 
-  const fetchUrl = '/query?person-type=' + personType +
-      '&action=' + action +
-      '&location=' + location;
-  
-  fetch(fetchUrl) 
-    .then((response) => {
-      if (response.ok) {
-        response.json().then((jsonResponse) => JSON.parse(jsonResponse))
-        .then((data) => {
-          // data is a 2D array, where the first row is a header row and all
-          // subsequent rows are one piece of data (e.g. for a state or county)
-          information.innerText = '';
-          displayVisualization(data);
-        });
-      } else {
-        console.log(
-          `An error occurred: ${response.status}: ${response.statusText}`);
-      }
-    });
+  fetch('/query?person-type=' + personType + '&location=' + location)
+      .then((response) => {
+        if (response.ok) {
+          response.json().then((jsonResponse) => JSON.parse(jsonResponse))
+              .then((data) => {
+                // data is a 2D array, where the first row is a header row and all
+                // subsequent rows are one piece of data (e.g. for a state or county)
+                displayVisualization(data);
+              });
+        } else {
+          console.log('There was an error');
+        }
+      });
 }
 
-// displayVisualization takes in a data array representing the 2D array
-// returned  by the census API. The first row in the census Data array
-// is the header, which describes the type of data.
-// Eg: Header for the query that finds for populations of all counties is
-// ["NAME","S0201_001E","state","county"]
+// displayVisualization takes in a data array representing the 2D array returned by the
+// census API. The function creates the necessary visualization with the census data.
 function displayVisualization(censusDataArray) {
   if (censusDataArray[0][2] == 'state' && censusDataArray[0][3] != 'county') {
     google.charts.setOnLoadCallback(drawRegionsMap(censusDataArray));
   } else {
     // We currently do not have counties implemented
-    const errorMessage = 'We do not support this visualization yet';
     document.getElementById('map').innerHTML = '';
-    document.getElementById('more-info').innerHTML = errorMessage;
+    document.getElementById('more-info').innerHTML = 'We do not have this information yet.';
   }
 }
 
-// Takes in a 2D array from the census API and displays the visualization
+// Takes in a 2D array from the census API and draws the appropriate visualization
 function drawRegionsMap(censusDataArray) {
   const shortDataArray = createDataArray(censusDataArray);
   const data = google.visualization.arrayToDataTable(shortDataArray);
   const options = {
-    'region': 'US',
-    'resolution': 'provinces',
-    'colorAxis': {colors: ['white', 'blue']},
+    colorAxis: {colors: ['white', 'blue']},
+    height: 550,
+    region: 'US',
+    resolution: 'provinces',
   };
-  const mapElement = document.getElementById('map');
-  const chart = new google.visualization.GeoChart(mapElement);
+  document.getElementById('result').style.display = 'block';
+  const chart = new google.visualization.GeoChart(document.getElementById('map'));
   chart.draw(data, options);
-  const mapNote = 'Populations are in thousands';
-  document.getElementById('more-info').innerHTML = mapNote;
+  document.getElementById('more-info').innerHTML =
+      'These populations are divided by 1000';
 }
 
-// createDataArray takes in the data array returned by the census API
-// and reformats it into a data table for the visualization API.
+// createDataArray takes in the data array returned by the census API and reformats it
+// into a data table that can be processed by the visualization API.
 function createDataArray(censusDataArray) {
   const vizDataArray = [];
   censusDataArray.forEach((state) => {
     vizDataArray.push([state[0], state[1]/1000]);
   });
-  // Changes the header of the vizDataArray to match the Visualization API
   vizDataArray[0][0] = 'State';
   vizDataArray[0][1] = 'Population';
   return vizDataArray;
 }
+
+function resizeVisualization() {
+  passQuery();
+}
+
+window.addEventListener('resize', resizeVisualization);


### PR DESCRIPTION
Turned off indentation checking for JavaScript. To auto fix linting issues for JS, you'll need npm to install eslint. You can install npm with "sudo apt-get install npm", then install eslint with "sudo npm install -g eslint". 

The google java formatter doesn't allow configuring the linter, so right now I have it printing the correctly formatted file in the test output. I fixed Java formatting issues by copying the corrected file into VSCode. The selecting in the test output is finicky, if you scroll it unselects what you'd selected. I can also completely remove the Java linter if that'd be simpler.