### PR TITLE
Switch location dropdown to write-in (datalist)

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -28,11 +28,14 @@
             <option value="work">work in</option>
             <option value="moved">moved to</option>
           </select>
-          every US
-          <select name="location">
-            <option value="county">county</option>
-            <option value="state">state</option>
-          </select>
+          <input type="list" list="location" name="location" pattern="every US state|California|New Jersey">
+            <datalist id="location">
+              <option data-value="state" value="every US state">
+              <option data-value="county" value="California">
+              <option data-value="county" value="New Jersey">
+              <!-- will change latter two to 06 and 31 (state numbers) when counties are ready -->
+            </datalist>
+          </input>
           ?
         </p>
         <input type="submit">

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -22,10 +22,13 @@ function passQuery() {
   document.getElementById('result').style.display = 'block';
   const information = document.getElementById('more-info');
   information.innerText = 'Please wait. Loading...';
+
   const query = new FormData(document.getElementById('query-form'));
   const personType = query.get('person-type');
   const action = query.get('action');
-  const location = query.get('location');
+  const locationName = query.get('location');
+  const location = document.querySelector("#location option[value='"+locationName+"']").dataset.value;
+
   const fetchUrl = '/query?person-type=' + personType +
       '&action=' + action +
       '&location=' + location;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -11,8 +11,7 @@ select {
 }
 
 input[type=list]:focus,
-select:focus
- {
+select:focus {
   outline: none;
 }
 

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -2,6 +2,7 @@
   font-family: 'Roboto', sans-serif;
 }
 
+input[type=list],
 select {
   background-color: transparent;
   border-style: none none solid none;
@@ -9,7 +10,9 @@ select {
   padding: 10px;
 }
 
-select:focus {
+input[type=list]:focus,
+select:focus
+ {
   outline: none;
 }
 


### PR DESCRIPTION
The location dropdown is now an HTML datalist instead of a select. That means that the user can write in the box, and the dropdown will show them only the options containing the string they've written (e.g. "n" shows New Jersey and California, but "ne" only shows New Jersey). 

I also updated the dropdown so that instead of having "every county" and "every state", it has "every state", "California", and "New Jersey". For now, choosing CA or NJ will get you the same not-yet message as choosing every county, but my thought was that we could use one or both of those states as a test run for amcharts.