### PR TITLE
Display all errors with a relevant message

### DIFF
--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -34,7 +34,7 @@ public class QueryServlet extends HttpServlet {
     if (!queryToDataRow.containsKey(action)
         || !queryToDataRow.get(action).containsKey(personType)) {
       // We don't have a data table for this query
-      response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, "We do not support this visualization yet.");
       return;
     }
 
@@ -51,7 +51,8 @@ public class QueryServlet extends HttpServlet {
 
     if (connection.getResponseCode() > 299) {
       // An error occurred
-      response.setStatus(HttpServletResponse.SC_BAD_GATEWAY);
+      response.sendError(HttpServletResponse.SC_BAD_GATEWAY, 
+          "An error occurred while trying to retrieve census data.");
     } else {
       response.setStatus(HttpServletResponse.SC_OK);
       String data = "";

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -53,7 +53,7 @@ public class QueryServlet extends HttpServlet {
     if (connection.getResponseCode() > 299) {
       // An error occurred
       response.sendError(
-          HttpServletResponse.SC_BAD_GATEWAY, 
+          HttpServletResponse.SC_BAD_GATEWAY,
           "An error occurred while trying to retrieve census data.");
     } else {
       response.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -34,7 +34,8 @@ public class QueryServlet extends HttpServlet {
     if (!queryToDataRow.containsKey(action)
         || !queryToDataRow.get(action).containsKey(personType)) {
       // We don't have a data table for this query
-      response.sendError(HttpServletResponse.SC_BAD_REQUEST, "We do not support this visualization yet.");
+      response.sendError(
+          HttpServletResponse.SC_BAD_REQUEST, "We do not support this visualization yet.");
       return;
     }
 
@@ -51,7 +52,8 @@ public class QueryServlet extends HttpServlet {
 
     if (connection.getResponseCode() > 299) {
       // An error occurred
-      response.sendError(HttpServletResponse.SC_BAD_GATEWAY, 
+      response.sendError(
+          HttpServletResponse.SC_BAD_GATEWAY, 
           "An error occurred while trying to retrieve census data.");
     } else {
       response.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -28,7 +28,8 @@ function passQuery() {
   const action = query.get('action');
 
   const locationName = query.get('location');
-  const location = document.querySelector("#location option[value='"+locationName+"']").dataset.value;
+  const location = document.querySelector(
+    "#location option[value='"+locationName+"']").dataset.value;
 
   const region =
       location === 'state' ? 'U.S. state' : 'State Name county';
@@ -69,7 +70,7 @@ function displayVisualization(censusDataArray, title) {
     google.charts.setOnLoadCallback(drawRegionsMap(censusDataArray, title));
   } else {
     // We currently do not have counties implemented
-    displayError(400, 'We do not support this visualization yet.');  
+    displayError(400, 'We do not support this visualization yet.');
   }
 }
 

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -29,7 +29,7 @@ function passQuery() {
 
   const locationName = query.get('location');
   const location = document.querySelector(
-    "#location option[value='"+locationName+"']").dataset.value;
+    '#location option[value=\''+locationName+'\']').dataset.value;
 
   const region =
       location === 'state' ? 'U.S. state' : 'State Name county';

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -20,9 +20,8 @@ google.charts.load('current', {
 
 function passQuery() {
   document.getElementById('map-title').innerText = '';
+  document.getElementById('more-info').innerText = 'Please wait. Loading...';
   document.getElementById('result').style.display = 'block';
-  const information = document.getElementById('more-info');
-  information.innerText = 'Please wait. Loading...';
 
   const query = new FormData(document.getElementById('query-form'));
   const personType = query.get('person-type');
@@ -46,14 +45,18 @@ function passQuery() {
         .then((data) => {
           // data is a 2D array, where the first row is a header row and all
           // subsequent rows are one piece of data (e.g. for a state or county)
-          information.innerText = '';
           displayVisualization(data, title);
         });
       } else {
-        console.log(
-          `An error occurred: ${response.status}: ${response.statusText}`);
+        displayError(response.status, response.statusText);
       }
     });
+}
+
+// Display an error on the front end
+function displayError(status, statusText) {
+  document.getElementById('map').innerHTML = '';
+  document.getElementById('more-info').innerText = `Error ${status}: ${statusText}`;
 }
 
 // displayVisualization takes in a data array representing the 2D array
@@ -66,9 +69,7 @@ function displayVisualization(censusDataArray, title) {
     google.charts.setOnLoadCallback(drawRegionsMap(censusDataArray, title));
   } else {
     // We currently do not have counties implemented
-    const errorMessage = 'We do not support this visualization yet';
-    document.getElementById('map').innerHTML = '';
-    document.getElementById('more-info').innerHTML = errorMessage;
+    displayError(400, 'We do not support this visualization yet.');  
   }
 }
 

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -54,7 +54,7 @@ input[type=submit]:focus {
   border-radius: 10px;
   box-shadow: 5px 5px 15px #e7e7e9;
   display: none;
-  margin: 60px 0 60px 0;
+  margin: 30px 0 60px 0;
   padding: 30px;
 }
 


### PR DESCRIPTION
Display all errors on the front end with a status code and message about what the error is.

I added a (for now, very simple) JS function to start to make error handling more robust for the future as well. If the census server breaks in some way while the data is being fetched, the user will see "Error 403: An error occurred while trying to retrieve census data." If they submit a query for any visualization we don't have right now, they'll see "Error 400: We do not support this visualization yet."