### PR TITLE
Update location dropdown

### DIFF
--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -19,8 +19,10 @@
         <p>
           How many
           <input type="list" list="person-type" name="person-type" id="person-type-list"
-              autocomplete="off" required onkeyup="validateInput('person-type', 'person-type-list')"
-              onfocus="this.value=''" value="people" pattern="children|adults|people">
+              autocomplete="off" required onkeyup="validateInput('person-type')"
+              onfocus="storeValueAndEmpty('person-type')" 
+              onfocusout="replaceValueIfEmpty('person-type')"
+              value="people" pattern="children|adults|people">
             <datalist id="person-type">
               <option data-value="under-18" value="children">
               <option data-value="over-18" value="adults">
@@ -29,8 +31,10 @@
           </input>
 
           <input type="list" list="action" name="action" id="action-list"
-              autocomplete="off" required onkeyup="validateInput('action', 'action-list')"
-              onfocus="this.value=''" value="live in" pattern="live in|work in|moved to" >
+              autocomplete="off" required onkeyup="validateInput('action')"
+              onfocus="storeValueAndEmpty('action')" 
+              onfocusout="replaceValueIfEmpty('action')"
+              value="live in" pattern="live in|work in|moved to" >
             <datalist id="action">
               <option data-value="live" value="live in">
               <option data-value="work" value="work in">
@@ -39,8 +43,10 @@
           </input>
 
           <input type="list" list="location" name="location" id="location-list"
-              autocomplete="off" required onkeyup="validateInput('location', 'location-list')"
-              onfocus="this.value=''" value="every US state" pattern="every US state|California|New Jersey">
+              autocomplete="off" required onkeyup="validateInput('location')"
+              onfocus="storeValueAndEmpty('location')" 
+              onfocusout="replaceValueIfEmpty('location')"
+              value="every US state" pattern="every US state|California|New Jersey">
             <datalist id="location">
               <option data-value="state" value="every US state">
               <option data-value="county" value="California">

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -28,7 +28,8 @@
             <option value="work">work in</option>
             <option value="moved">moved to</option>
           </select>
-          <input type="list" list="location" name="location" pattern="every US state|California|New Jersey">
+          <input type="list" list="location" name="location" id="locationlist"
+          required onkeyup="validateLocation()" pattern="every US state|California|New Jersey">
             <datalist id="location">
               <option data-value="state" value="every US state">
               <option data-value="county" value="California">

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -28,7 +28,6 @@
             </datalist>
           </input>
 
-    
           <input type="list" list="action" name="action" id="action-list"
               autocomplete="off" required onkeyup="validateInput('action', 'action-list')"
               onfocus="this.value=''" value="live in" pattern="live in|work in|moved to" >

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -18,19 +18,30 @@
       <form id="query-form" onsubmit="passQuery(); return false;">
         <p>
           How many
-          <select name="person-type">
-            <option value="under-18">children</option>
-            <option value="over-18">adults</option>
-            <option value="all-ages">people</option>
-          </select>
-          <select name="action">
-            <option value="live">live in</option>
-            <option value="work">work in</option>
-            <option value="moved">moved to</option>
-          </select>
-          <input type="list" list="location" name="location" id="locationlist"
-              autocomplete="off" required onkeyup="validateInput('location', 'locationlist')"
-              onfocus="this.value=''" pattern="every US state|California|New Jersey">
+          <input type="list" list="person-type" name="person-type" id="person-type-list"
+              autocomplete="off" required onkeyup="validateInput('person-type', 'person-type-list')"
+              onfocus="this.value=''" value="people" pattern="children|adults|people">
+            <datalist id="person-type">
+              <option data-value="under-18" value="children">
+              <option data-value="over-18" value="adults">
+              <option data-value="all-ages" value="people">
+            </datalist>
+          </input>
+
+    
+          <input type="list" list="action" name="action" id="action-list"
+              autocomplete="off" required onkeyup="validateInput('action', 'action-list')"
+              onfocus="this.value=''" value="live in" pattern="live in|work in|moved to" >
+            <datalist id="action">
+              <option data-value="live" value="live in">
+              <option data-value="work" value="work in">
+              <option data-value="moved" value="moved to">
+            </datalist>
+          </input>
+
+          <input type="list" list="location" name="location" id="location-list"
+              autocomplete="off" required onkeyup="validateInput('location', 'location-list')"
+              onfocus="this.value=''" value="every US state" pattern="every US state|California|New Jersey">
             <datalist id="location">
               <option data-value="state" value="every US state">
               <option data-value="county" value="California">

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -29,7 +29,7 @@
             <option value="moved">moved to</option>
           </select>
           <input type="list" list="location" name="location" id="locationlist"
-          autocomplete="off" required onkeyup="validateLocation()" 
+          autocomplete="off" required onkeyup="validateLocation()"
           onfocus="this.value=''" pattern="every US state|California|New Jersey" >
             <datalist id="location">
               <option data-value="state" value="every US state">

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -29,8 +29,8 @@
             <option value="moved">moved to</option>
           </select>
           <input type="list" list="location" name="location" id="locationlist"
-          autocomplete="off" required onkeyup="validateLocation()"
-          onfocus="this.value=''" pattern="every US state|California|New Jersey" >
+              autocomplete="off" required onkeyup="validateInput('location', 'locationlist')"
+              onfocus="this.value=''" pattern="every US state|California|New Jersey">
             <datalist id="location">
               <option data-value="state" value="every US state">
               <option data-value="county" value="California">

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -29,7 +29,8 @@
             <option value="moved">moved to</option>
           </select>
           <input type="list" list="location" name="location" id="locationlist"
-          required onkeyup="validateLocation()" pattern="every US state|California|New Jersey">
+          autocomplete="off" required onkeyup="validateLocation()" 
+          onfocus="this.value=''" pattern="every US state|California|New Jersey" >
             <datalist id="location">
               <option data-value="state" value="every US state">
               <option data-value="county" value="California">

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -60,25 +60,20 @@ function passQuery() {
     });
 }
 
-function validateLocation() {
-  const datalist = document.getElementById('location');
-  const inputlist = document.getElementById('locationlist');
-
+function validateInput(dataListId, inputListId) {
+  const datalist = document.getElementById(dataListId);
+  const inputlist = document.getElementById(inputListId);
   const options = datalist.options;
   const typedSoFar = inputlist.value.toLowerCase();
-  let matchesAnOption = false;
 
   for (const option of options) {
     if (option.value.toLowerCase().includes(typedSoFar)) {
-      matchesAnOption = true;
-      inputlist.style.borderColor = '#767676'; // dark gray
-      inputlist.style.borderStyle = 'none none solid none';
+      inputlist.className = 'input-valid'; // At least one match present
+      return;
     }
   }
-  if (!matchesAnOption) {
-    inputlist.style.borderColor = 'red';
-    inputlist.style.borderStyle = 'solid';
-  }
+  // Didn't find any matches
+  inputlist.className = 'input-invalid';
 }
 
 // Display an error on the front end

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -65,11 +65,11 @@ function validateLocation() {
   const inputlist = document.getElementById('locationlist');
 
   const options = datalist.options;
-  const typedSoFar = inputlist.value;
+  const typedSoFar = inputlist.value.toLowerCase();
   let matchesAnOption = false;
 
   for (let option of options) {
-    if (option.value.includes(typedSoFar)) {
+    if (option.value.toLowerCase().includes(typedSoFar)) {
       matchesAnOption = true;
       inputlist.style.borderColor = '#767676'; // dark gray
       inputlist.style.borderStyle = 'none none solid none';

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -24,19 +24,24 @@ function passQuery() {
   document.getElementById('result').style.display = 'block';
 
   const query = new FormData(document.getElementById('query-form'));
-  const personType = query.get('person-type');
-  const action = query.get('action');
+
+  const personTypeInput = query.get('person-type');
+  const actionInput = query.get('action');
+  const locationInput = query.get('location');
+
+  const personType = document.querySelector(
+    '#person-type option[value=\'' + personTypeInput + '\']').dataset.value;
+  const action = document.querySelector(
+      '#action option[value=\'' + actionInput + '\']').dataset.value;
+  const location = document.querySelector(
+    '#location option[value=\'' + locationInput + '\']').dataset.value;
+
   const actionToText = new Map();
   actionToText['moved'] = 'moved to';
   if (actionToText.has(action)) {
     action = actionToText[action];
   }
   const description = {action: action, age: personType};
-
-  const locationName = query.get('location');
-  const location = document.querySelector(
-    '#location option[value=\''+locationName+'\']').dataset.value;
-
   const region =
       location === 'state' ? 'U.S. state' : 'State Name county';
   const title = 'Population who ' + action +

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -30,7 +30,7 @@ function passQuery() {
   actionToText['moved'] = 'moved to';
   if (actionToText.has(action)) {
     action = actionToText[action];
-  } 
+  }
   const description = {action: action, age: personType};
 
   const locationName = query.get('location');
@@ -68,7 +68,7 @@ function validateLocation() {
   const typedSoFar = inputlist.value.toLowerCase();
   let matchesAnOption = false;
 
-  for (let option of options) {
+  for (const option of options) {
     if (option.value.toLowerCase().includes(typedSoFar)) {
       matchesAnOption = true;
       inputlist.style.borderColor = '#767676'; // dark gray
@@ -154,7 +154,7 @@ function percentToTotal(totalNumber, percentage) {
   return (totalNumber/100) * percentage;
 }
 
-// checkPercentage() Takes in the header of a census query and returns 
+// checkPercentage() Takes in the header of a census query and returns
 // whether or not the total needs to be calculated using the percentToTotal() function
 function checkPercentage(headerColumn) {
   // percentageQueries is a list of queries that return percents and not raw

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -30,11 +30,11 @@ function passQuery() {
   const locationInput = query.get('location');
 
   const personType = document.querySelector(
-    '#person-type option[value=\'' + personTypeInput + '\']').dataset.value;
+      '#person-type option[value=\'' + personTypeInput + '\']').dataset.value;
   const action = document.querySelector(
       '#action option[value=\'' + actionInput + '\']').dataset.value;
   const location = document.querySelector(
-    '#location option[value=\'' + locationInput + '\']').dataset.value;
+      '#location option[value=\'' + locationInput + '\']').dataset.value;
 
   const actionToText = new Map();
   actionToText['moved'] = 'moved to';
@@ -65,9 +65,11 @@ function passQuery() {
     });
 }
 
-function validateInput(dataListId, inputListId) {
+// Check that the input being written to a datalist can match one of its options
+// Note: assumes that the input list has id equal to the datalist's id + '-list'
+function validateInput(dataListId) {
   const datalist = document.getElementById(dataListId);
-  const inputlist = document.getElementById(inputListId);
+  const inputlist = document.getElementById(dataListId+'-list');
   const options = datalist.options;
   const typedSoFar = inputlist.value.toLowerCase();
 
@@ -85,6 +87,26 @@ function validateInput(dataListId, inputListId) {
 function displayError(status, statusText) {
   document.getElementById('map').innerHTML = '';
   document.getElementById('more-info').innerText = `Error ${status}: ${statusText}`;
+}
+
+// Note the value of a field and then empty it.
+let storedVal = '';
+function storeValueAndEmpty(dataListId) {
+  const inputlist = document.getElementById(dataListId+'-list');
+  storedVal = inputlist.value;
+  inputlist.value = '';
+}
+
+// If a field is empty, replace it with the value it had directly prior to being emptied.
+// Since this function is called on focus out, it will always be called
+// directly after storeValueAndEmpty, which is called on focus in.
+// Therefore, the most recently stored value will always be the one we want.
+function replaceValueIfEmpty(dataListId) {
+  const inputlist = document.getElementById(dataListId+'-list');
+  const typedSoFar = inputlist.value;
+  if (typedSoFar === '') {
+    inputlist.value = storedVal;
+  }
 }
 
 // displayVisualization takes in a data array representing the 2D array

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -60,6 +60,27 @@ function passQuery() {
     });
 }
 
+function validateLocation() {
+  const datalist = document.getElementById('location');
+  const inputlist = document.getElementById('locationlist');
+
+  const options = datalist.options;
+  const typedSoFar = inputlist.value;
+  let matchesAnOption = false;
+
+  for (let option of options) {
+    if (option.value.includes(typedSoFar)) {
+      matchesAnOption = true;
+      inputlist.style.borderColor = '#767676'; // dark gray
+      inputlist.style.borderStyle = 'none none solid none';
+    }
+  }
+  if (!matchesAnOption) {
+    inputlist.style.borderColor = 'red';
+    inputlist.style.borderStyle = 'solid';
+  }
+}
+
 // Display an error on the front end
 function displayError(status, statusText) {
   document.getElementById('map').innerHTML = '';

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -16,6 +16,16 @@ select:focus {
   outline: none;
 }
 
+.input-valid {
+  border-color: #767676;
+  border-style: none none solid none;
+}
+
+.input-invalid {
+  border-color: red;
+  border-style: solid !important;
+}
+
 .wrapper {
   margin: 0 60px 0 60px;
 }

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -5,6 +5,7 @@
 input[type=list],
 select {
   background-color: transparent;
+  border-radius: 2px;
   border-style: none none solid none;
   font: 16px 'Roboto', sans-serif;
   padding: 10px;


### PR DESCRIPTION
https://censusviz.appspot.com/
New: all boxes are now datalists (with default inputs given).

Update location dropdown so that it alerts the user if they begin to type an option that does not exist, and so that it empties itself when the user returns to make a second query.

The location box will now turn red when you type a string that is not contained inside any of the datalist's options. Every time you click back into the datalist, it will empty itself and show you the full list of options again. 
I also added code to turn the autocomplete feature off that Sriram was seeing, but since I never saw it in the first place, I can't verify that it works. 
Lastly, it is no longer possible to submit with that field empty.