### PR TITLE
Fixed setStyle() function

### DIFF
--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -391,14 +391,12 @@ function setStyle(isCountyQuery) {
   if (isCountyQuery) {
     const buttonsDiv = document.getElementById('buttons');
     buttonsDiv.style.display = 'block';
-    const chartsDiv = document.getElementById('am-charts');
-    chartsDiv.style.display = 'block';
   } else {
     const buttonsDiv = document.getElementById('buttons');
     buttonsDiv.style.display = 'none';
-    const mapsDiv = document.getElementById('map');
-    mapsDiv.style.display = 'none';
-    const amChartsDiv = document.getElementById('am-charts');
-    amChartsDiv.style.display = 'block';
   }
+  const chartsDiv = document.getElementById('am-charts');
+  chartsDiv.style.display = 'block';
+  const mapsDiv = document.getElementById('map');
+  mapsDiv.style.display = 'none';
 }


### PR DESCRIPTION
Fixes a tiny bug in the setStyle() function. Fixes the function to always show amCharts as the default when a new query is sent in order to avoid the bug where the two divs were visible at the same time. 
Deployed at https://censusviz.appspot.com/
