### PR TITLE
Add man and woman queries; update percentage checker

### DIFF
--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -37,7 +37,7 @@ public class QueryServlet extends HttpServlet {
     } else if (tablePrefix.substring(0, 1).equals("S")) {
       return "subject?get=NAME,";
     }
-    return ""; // Will throw error when query is made; should never reach this point
+    return ""; // should never reach this point
   }
 
   @Override
@@ -61,10 +61,16 @@ public class QueryServlet extends HttpServlet {
     }
 
     String dataRow = queryToDataRow.get(action).get(personType);
+    String dataTablePrefix = getDataTableString(dataRow);
+    if (dataTablePrefix.equals("")) {
+      response.sendError(
+          HttpServletResponse.SC_NOT_IMPLEMENTED, "We do not support this visualization yet.");
+    }
+
     URL fetchUrl =
         new URL(
             "https://api.census.gov/data/2018/acs/acs1/"
-                + getDataTableString(dataRow)
+                + dataTablePrefix
                 + dataRow
                 + "&for="
                 + (location.equals("state") ? "state:*" : "county:*&in=state:" + location)

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -46,15 +46,21 @@ public class QueryServlet extends HttpServlet {
     String action = request.getParameter("action");
     String location = request.getParameter("location");
 
-    if (!queryToDataRow.containsKey(action)
-        || !queryToDataRow.get(action).containsKey(personType)) {
-      // We don't have a data table for this query
+    if (!queryToDataRow.containsKey(action)) {
+      // We don't have information on this action
       response.sendError(
-          HttpServletResponse.SC_BAD_REQUEST, "We do not support this visualization yet.");
+          HttpServletResponse.SC_NOT_IMPLEMENTED, "We do not support this visualization yet.");
+      return;
+    } else if (!queryToDataRow.get(action).containsKey(personType)) {
+      // This action doesn't make sense with this type of person,
+      // or the census doesn't keep data on it that we could find
+      response.sendError(
+          HttpServletResponse.SC_BAD_REQUEST, 
+          "This query is not supported by census data. Try asking a more general one.");
       return;
     }
-    String dataRow = queryToDataRow.get(action).get(personType);
 
+    String dataRow = queryToDataRow.get(action).get(personType);
     URL fetchUrl =
         new URL(
             "https://api.census.gov/data/2018/acs/acs1/"

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -15,15 +15,30 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/query")
 public class QueryServlet extends HttpServlet {
 
-  // Hardcoded initial choices for which lines of the data table are accessed
+  // Hardcoded initial choices for which lines of which data table are accessed
   Map<String, Map<String, String>> queryToDataRow =
       ImmutableMap.of(
           "live",
-          ImmutableMap.of("under-18", "0019E", "over-18", "0021E", "all-ages", "0001E"),
+          ImmutableMap.of("under-18", "DP05_0019E", "over-18", "DP05_0021E", 
+              "all-ages", "DP05_0001E", "male", "DP05_0002E", "female", "DP05_0003E"),
           "work",
-          ImmutableMap.of("over-18", "154E,S0201_157E"),
+          ImmutableMap.of("all-ages", "DP03_0004E", "over-18", "DP03_0004E",
+              "male", "S0201_182E", "female", "DP03_0013E"),
           "moved",
-          ImmutableMap.of("all-ages", "119E,S0201_126E"));
+          ImmutableMap.of("all-ages", "S0201_119E,S0201_126E", 
+              "male", "S0701_C01_012E,S0701_C04_012E", "female", "S0701_C01_013E,S0701_C04_013E"));
+
+  // Depending on the beginning of the data table string, the query URL changes slightly
+  private String getDataTableString(String tablePrefix) {
+    if (tablePrefix.substring(0,1).equals("D")) {
+      return "profile?get=NAME,";
+    } else if (tablePrefix.substring(0,5).equals("S0201")) {
+      return "spp?get=NAME,"; // Special case - different from the other S tables
+    } else if (tablePrefix.substring(0,1).equals("S")) {
+      return "subject?get=NAME,";
+    }
+    return ""; // Will throw error when query is made; should never reach this point
+  }
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -38,12 +53,13 @@ public class QueryServlet extends HttpServlet {
           HttpServletResponse.SC_BAD_REQUEST, "We do not support this visualization yet.");
       return;
     }
+    String dataRow = queryToDataRow.get(action).get(personType);
 
     URL fetchUrl =
         new URL(
             "https://api.census.gov/data/2018/acs/acs1/"
-                + (action.equals("live") ? "profile?get=NAME,DP05_" : "spp?get=NAME,S0201_")
-                + queryToDataRow.get(action).get(personType)
+                + getDataTableString(dataRow)
+                + dataRow
                 + "&for="
                 + (location.equals("state") ? "state:*" : "county:*&in=state:" + location)
                 + "&key=ea65020114ffc1e71e760341a0285f99e73eabbc");

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -30,11 +30,11 @@ public class QueryServlet extends HttpServlet {
 
   // Depending on the beginning of the data table string, the query URL changes slightly
   private String getDataTableString(String tablePrefix) {
-    if (tablePrefix.substring(0,1).equals("D")) {
+    if (tablePrefix.substring(0, 1).equals("D")) {
       return "profile?get=NAME,";
-    } else if (tablePrefix.substring(0,5).equals("S0201")) {
+    } else if (tablePrefix.substring(0, 5).equals("S0201")) {
       return "spp?get=NAME,"; // Special case - different from the other S tables
-    } else if (tablePrefix.substring(0,1).equals("S")) {
+    } else if (tablePrefix.substring(0, 1).equals("S")) {
       return "subject?get=NAME,";
     }
     return ""; // Will throw error when query is made; should never reach this point
@@ -55,7 +55,7 @@ public class QueryServlet extends HttpServlet {
       // This action doesn't make sense with this type of person,
       // or the census doesn't keep data on it that we could find
       response.sendError(
-          HttpServletResponse.SC_BAD_REQUEST, 
+          HttpServletResponse.SC_BAD_REQUEST,
           "This query is not supported by census data. Try asking a more general one.");
       return;
     }

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -137,7 +137,7 @@ function createDataArray(censusDataArray, isCountyQuery) {
         id: getLocationId(location, isCountyQuery, regionIndex),
         name: location[0],
         value: percentToTotal(location[1], location[2])});
-        appendRowToDataTable(table, location[0], 
+        appendRowToDataTable(table, location[0],
           percentToTotal(location[1], location[2]));
     });
   } else {
@@ -172,9 +172,9 @@ function checkPercentage(headerColumn) {
   }
   firstNum = Number(headerColumn[1]);
   secondNum = Number(headerColumn[2]);
-  return !(isNaN(firstNum) || isNaN(secondNum)) 
-      && ((firstNum > 100 && secondNum >= 0 && secondNum <= 100)
-          || (secondNum > 100 && firstNum >= 0 && firstNum <= 100))
+  return !(isNaN(firstNum) || isNaN(secondNum)) &&
+      ((firstNum > 100 && secondNum >= 0 && secondNum <= 100) ||
+          (secondNum > 100 && firstNum >= 0 && firstNum <= 100));
 }
 
 // Returns an object containing all of the relevant data in order
@@ -241,7 +241,7 @@ async function displayCountyGeoJson(mapsData, stateNumber) {
   const colorScale = chroma.scale(['white', 'blue']).domain([minPopulation,
     maxPopulation]);
   const geoData = await getGeoData(stateNumber, true);
-  
+
   map.data.addGeoJson(geoData);
   map.data.forEach(function(feature) {
     map.data.setStyle((feature) => {

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -163,10 +163,10 @@ function percentToTotal(totalNumber, percentage) {
 // whether or not the total needs to be calculated using the
 // percentToTotal() function
 function checkPercentage(headerColumn, isCountyQuery) {
-  // percentageQueries is a list of queries that return percents and not raw data.
-  // These queries have two columns of numbers instead of one. 
-  // One is a total number and one is a number between 0 and 100
-  // (representing the percentage of the total).
+  // Queries that are percentages will have two columns of numbers instead
+  // of one, where one is a total number and one is a number between 0 and 100
+  // (which represents the percentage of the total).
+  // County queries always have one more column (to list both county and state)
   if ((!isCountyQuery && headerColumn.length !== 4) ||
       (isCountyQuery && headerColumn.length !== 5)) {
     return false;

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -131,7 +131,7 @@ function createDataArray(censusDataArray, isCountyQuery) {
   censusDataArray = censusDataArray.slice(1); // get rid of header row
   // Check to see if an extra calculation for percentages is needed
   const table = initDataTable(isCountyQuery);
-  if (checkPercentage(censusDataArray[0])) {
+  if (checkPercentage(censusDataArray[0], isCountyQuery)) {
     censusDataArray.forEach((location) => {
       vizDataArray.push({
         id: getLocationId(location, isCountyQuery, regionIndex),
@@ -156,24 +156,26 @@ function createDataArray(censusDataArray, isCountyQuery) {
 // percentToTotal takes in the total number of people in a category
 // and the percentage and returns the total
 function percentToTotal(totalNumber, percentage) {
-  return round((totalNumber/100) * percentage);
+  return Math.round((totalNumber/100) * percentage);
 }
 
 // checkPercentage() Takes in the header of a census query and returns
 // whether or not the total needs to be calculated using the
 // percentToTotal() function
-function checkPercentage(headerColumn) {
+function checkPercentage(headerColumn, isCountyQuery) {
   // percentageQueries is a list of queries that return percents and not raw data.
-  // These queries have two columns of numbers. One is a total number and one
-  // is a number between 0 and 100 (representing the percentage of the total)
-  if (headerColumn.length !== 4) {
+  // These queries have two columns of numbers instead of one. 
+  // One is a total number and one is a number between 0 and 100 
+  // (representing the percentage of the total).
+  if ((!isCountyQuery && headerColumn.length !== 4) || 
+      (isCountyQuery && headerColumn.length !== 5)) {
     return false;
   }
   const firstNum = Number(headerColumn[1]);
   const secondNum = Number(headerColumn[2]);
   return !(isNaN(firstNum) || isNaN(secondNum)) &&
       ((firstNum > 100 && secondNum >= 0 && secondNum <= 100) ||
-          (secondNum > 100 && firstNum >= 0 && firstNum <= 100));
+      (secondNum > 100 && firstNum >= 0 && firstNum <= 100));
 }
 
 // Returns an object containing all of the relevant data in order

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -156,9 +156,8 @@ function createDataArray(censusDataArray, isCountyQuery) {
 // percentToTotal takes in the total number of people in a category
 // and the percentage and returns the total
 function percentToTotal(totalNumber, percentage) {
-  return (totalNumber/100) * percentage;
+  return round((totalNumber/100) * percentage);
 }
-
 
 // checkPercentage() Takes in the header of a census query and returns
 // whether or not the total needs to be calculated using the
@@ -170,8 +169,8 @@ function checkPercentage(headerColumn) {
   if (headerColumn.length !== 4) {
     return false;
   }
-  firstNum = Number(headerColumn[1]);
-  secondNum = Number(headerColumn[2]);
+  const firstNum = Number(headerColumn[1]);
+  const secondNum = Number(headerColumn[2]);
   return !(isNaN(firstNum) || isNaN(secondNum)) &&
       ((firstNum > 100 && secondNum >= 0 && secondNum <= 100) ||
           (secondNum > 100 && firstNum >= 0 && firstNum <= 100));

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -165,9 +165,9 @@ function percentToTotal(totalNumber, percentage) {
 function checkPercentage(headerColumn, isCountyQuery) {
   // percentageQueries is a list of queries that return percents and not raw data.
   // These queries have two columns of numbers instead of one. 
-  // One is a total number and one is a number between 0 and 100 
+  // One is a total number and one is a number between 0 and 100
   // (representing the percentage of the total).
-  if ((!isCountyQuery && headerColumn.length !== 4) || 
+  if ((!isCountyQuery && headerColumn.length !== 4) ||
       (isCountyQuery && headerColumn.length !== 5)) {
     return false;
   }

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -164,20 +164,17 @@ function percentToTotal(totalNumber, percentage) {
 // whether or not the total needs to be calculated using the
 // percentToTotal() function
 function checkPercentage(headerColumn) {
-  // percentageQueries is a list of queries that return percents and not raw
-  // data. It is hard coded for now.
-  const percentageQueries = ['S0201_157E', 'S0201_126E'];
-  let i;
-  // Iterate through all the data variables in the header.
-  // Eg: ["NAME","S0201_119E","S0201_126E","state"]
-  // We need to return true
-  for (i = 1; i < headerColumn.length - 1; i++) {
-    // if the current data is in the percentage array
-    if (percentageQueries.indexOf(headerColumn[i]) > -1) {
-      return true;
-    }
+  // percentageQueries is a list of queries that return percents and not raw data.
+  // These queries have two columns of numbers. One is a total number and one
+  // is a number between 0 and 100 (representing the percentage of the total)
+  if (headerColumn.length !== 4) {
+    return false;
   }
-  return false;
+  firstNum = Number(headerColumn[1]);
+  secondNum = Number(headerColumn[2]);
+  return !(isNaN(firstNum) || isNaN(secondNum)) 
+      && ((firstNum > 100 && secondNum >= 0 && secondNum <= 100)
+          || (secondNum > 100 && firstNum >= 0 && firstNum <= 100))
 }
 
 // Returns an object containing all of the relevant data in order

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -29,11 +29,13 @@
               autocomplete="off" required onkeyup="validateInput('person-type')"
               onfocus="storeValueAndEmpty('person-type')"
               onfocusout="replaceValueIfEmpty('person-type')"
-              value="people" pattern="children|adults|people">
+              value="people" pattern="children|adults|people|men|women">
             <datalist id="person-type">
               <option data-value="under-18" value="children"></option>
               <option data-value="over-18" value="adults"></option>
               <option data-value="all-ages" value="people"></option>
+              <option data-value="male" value="men"></option>
+              <option data-value="female" value="women"></option>
             </datalist>
           </input>
 


### PR DESCRIPTION
Add the option to ask about "men" or "women" via hardcoded queries. Also, change the percentage checker so that it is looking at numbers, not at hardcoded headers.

Note that actually, there was a bug in the percentage checker - it was originally using the data's header row to check the query name against a hardcoded list, but we started removing the header row earlier, so it was actually looking at the first row of real data.