### PR TITLE
Add year to query

### DIFF
--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -45,6 +45,7 @@ public class QueryServlet extends HttpServlet {
     String personType = request.getParameter("person-type");
     String action = request.getParameter("action");
     String location = request.getParameter("location");
+    String year = request.getParameter("year");
 
     if (!queryToDataRow.containsKey(action)) {
       // We don't have information on this action
@@ -63,7 +64,7 @@ public class QueryServlet extends HttpServlet {
     String dataRow = queryToDataRow.get(action).get(personType);
     URL fetchUrl =
         new URL(
-            "https://api.census.gov/data/2018/acs/acs1/"
+            "https://api.census.gov/data/" + year + "/acs/acs1/"
                 + getDataTableString(dataRow)
                 + dataRow
                 + "&for="

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -58,6 +58,24 @@
               value="each U.S. state">
             <datalist id="location"></datalist>
           </input>
+          in
+          <input type="list" list="year" name="year" id="year-list"
+              autocomplete="off" required onkeyup="validateInput('year')"
+              onfocus="storeValueAndEmpty('year')"
+              onfocusout="replaceValueIfEmpty('year')" 
+              value="2018" pattern="201[0-8]">
+            <datalist id="year">
+              <option value="2010"></option>
+              <option value="2011"></option>
+              <option value="2012"></option>
+              <option value="2013"></option>
+              <option value="2014"></option>
+              <option value="2015"></option>
+              <option value="2016"></option>
+              <option value="2017"></option>
+              <option value="2018"></option>
+            </datalist>
+          </input>
           ?
         </p>
         <input type="submit" value="go">

--- a/src/main/webapp/query-control.js
+++ b/src/main/webapp/query-control.js
@@ -34,6 +34,7 @@ function passQuery() {
   const personTypeInput = query.get('person-type');
   const actionInput = query.get('action');
   const locationInput = query.get('location');
+  const year = query.get('year');
 
   const personType = document.querySelector(
     '#person-type option[value=\'' + personTypeInput + '\']').dataset.value;
@@ -56,12 +57,15 @@ function passQuery() {
   } else {
     title += ' in ';
   }
-  title += 'each ' + region + ' (' + personType.replace('-', ' ') + ')';
+  title += 'each ' + region + ' (' + 
+      personType.replace('-', ' ') + ')'
+      + ' in ' + year;
   document.getElementById('map-title').innerText = title;
 
   const fetchUrl = '/query?person-type=' + personType +
     '&action=' + action +
-    '&location=' + location;
+    '&location=' + location +
+    '&year=' + year;
 
   fetch(fetchUrl)
     .then((response) => {


### PR DESCRIPTION
Allow users to choose which year (from 2010-2018) their query is about.

The years are chosen right now for simplicity; all of the data tables we're looking at have data for every year in 2010-2018 that can be accessed using identical queries. If we wanted to go further into the past, we'd likely have to make more adjustments.