### PR TITLE
Update API queries to access more counties' data

### DIFF
--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -97,7 +97,7 @@ public class QueryServlet extends HttpServlet {
             : (tableNameToAbbrev.get(dataTablePrefix.substring(1)) + "1Y"))
         + year
         + "."
-        + dataRow.substring(0, dataRow.indexOf("_"));
+        + dataRow.substring(0, (dataRow.contains("_") ? dataRow.indexOf("_") : dataRow.length() + 1));
   }
 
   @Override

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -4,7 +4,6 @@ import com.google.gson.JsonObject;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.lang.NoSuchFieldException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Map;

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -73,8 +73,8 @@ public class QueryServlet extends HttpServlet {
           "moved",
           ImmutableMap.of(
               "all-ages",
-              "S0201_119E,S0201_126E", /* TODO: K200701_005E + K200701_006E for state query,
-              but actually have to add K200701_004E for county query */);
+              "S0201_119E,S0201_126E"); /* TODO: K200701_005E + K200701_006E for state query,
+              but actually have to add K200701_004E as well for county query */
 
   Map<String, String> tableNameToAbbrev =
       ImmutableMap.of("profile", "DP", "spp", "SPP", "subject", "ST");

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -24,7 +24,7 @@ public class QueryServlet extends HttpServlet {
               "under-18",
               "DP05_0019E",
               "over-18",
-              "DP05_0021E", /* still available for post-2013 if you do math */
+              "DP05_0021E", /* TODO: could be added to post2013 using subtraction */
               "all-ages",
               "DP05_0001E",
               "male",
@@ -47,7 +47,7 @@ public class QueryServlet extends HttpServlet {
               "all-ages",
               "S0201_119E,S0201_126E",
               "male",
-              "S0701_C01_012E,S0701_C04_012E", 
+              "S0701_C01_012E,S0701_C04_012E",
               "female",
               "S0701_C01_013E,S0701_C04_013E"));
 
@@ -139,7 +139,7 @@ public class QueryServlet extends HttpServlet {
           HttpServletResponse.SC_NOT_IMPLEMENTED, "We do not support this visualization yet.");
     }
 
-    URL fetchUrl = /*BUG*/
+    URL fetchUrl =
         new URL(
             "https://api.census.gov/data/"
                 + year

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -91,7 +91,7 @@ public class QueryServlet extends HttpServlet {
 
   private String getcensusTableLink(String dataRow, String dataTablePrefix, String year) {
     return "https://data.census.gov/cedsci/table?tid=ACS"
-        + (dataRow.substring(0, 1).equals("K") 
+        + (dataRow.substring(0, 1).equals("K")
             ? "SE"
             : (tableNameToAbbrev.get(dataTablePrefix.substring(1)) + "1Y"))
         + year

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -73,7 +73,7 @@ public class QueryServlet extends HttpServlet {
           "moved",
           ImmutableMap.of(
               "all-ages",
-              "S0201_119E,S0201_126E"); /* TODO: K200701_005E + K200701_006E for state query,
+              "S0201_119E,S0201_126E")); /* TODO: K200701_005E + K200701_006E for state query,
               but actually have to add K200701_004E as well for county query */
 
   Map<String, String> tableNameToAbbrev =

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -42,7 +42,7 @@ public class QueryServlet extends HttpServlet {
               "female",
               "DP03_0013E"),
           "moved", /* TODO: All of these really should be two to three columns added together,
-          and then calculated as a percentage */
+                   and then calculated as a percentage */
           ImmutableMap.of(
               "all-ages",
               "S0201_119E,S0201_126E",
@@ -66,14 +66,12 @@ public class QueryServlet extends HttpServlet {
               "K200101_003E"),
           "work",
           ImmutableMap.of(
-              "all-ages",
-              "K202301_004E",
-              "over-18",
-              "K202301_004E"),
+              "all-ages", "K202301_004E", "over-18", "K202301_004E"),
           "moved",
           ImmutableMap.of(
               "all-ages",
-              "S0201_119E,S0201_126E")); /* TODO: K200701_005E + K200701_006E for state query,
+              "S0201_119E,S0201_126E")); 
+              /* TODO: K200701_005E + K200701_006E for state query,
               but actually have to add K200701_004E as well for county query */
 
   Map<String, String> tableNameToAbbrev =
@@ -96,8 +94,9 @@ public class QueryServlet extends HttpServlet {
 
   private String getcensusTableLink(String dataRow, String dataTablePrefix, String year) {
     return "https://data.census.gov/cedsci/table?tid=ACS"
-        + (dataRow.substring(0,1).equals("K") ? "SE" : 
-            (tableNameToAbbrev.get(dataTablePrefix.substring(1)) + "1Y"))
+        + (dataRow.substring(0,1).equals("K") 
+            ? "SE" 
+            : (tableNameToAbbrev.get(dataTablePrefix.substring(1)) + "1Y"))
         + year
         + "."
         + dataRow.substring(0, dataRow.indexOf("_"));
@@ -126,8 +125,9 @@ public class QueryServlet extends HttpServlet {
     }
     
     String dataRow;
-    if (year > 2013 && queryToDataRowPost2013.containsKey(action) && 
-      queryToDataRowPost2013.get(action).containsKey(personType)) {
+    if (year > 2013
+      && queryToDataRowPost2013.containsKey(action)
+      && queryToDataRowPost2013.get(action).containsKey(personType)) {
       dataRow = queryToDataRowPost2013.get(action).get(personType);
     } else {
       dataRow = queryToDataRowGeneric.get(action).get(personType);
@@ -144,7 +144,7 @@ public class QueryServlet extends HttpServlet {
             "https://api.census.gov/data/"
                 + year
                 + "/acs/"
-                + (dataRow.substring(0,1).equals("K") ? "acsse" : "acs1")
+                + (dataRow.substring(0, 1).equals("K") ? "acsse" : "acs1")
                 + dataTablePrefix
                 + "?get=NAME,"
                 + dataRow

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -65,14 +65,11 @@ public class QueryServlet extends HttpServlet {
               "female",
               "K200101_003E"),
           "work",
-          ImmutableMap.of(
-              "all-ages", "K202301_004E", "over-18", "K202301_004E"),
+          ImmutableMap.of("all-ages", "K202301_004E", "over-18", "K202301_004E"),
           "moved",
-          ImmutableMap.of(
-              "all-ages",
-              "S0201_119E,S0201_126E")); 
-              /* TODO: K200701_005E + K200701_006E for state query,
-              but actually have to add K200701_004E as well for county query */
+          /* TODO: K200701_005E + K200701_006E for state query,
+          but actually have to add K200701_004E as well for county query */
+          ImmutableMap.of("all-ages", "S0201_119E,S0201_126E")); 
 
   Map<String, String> tableNameToAbbrev =
       ImmutableMap.of("profile", "DP", "spp", "SPP", "subject", "ST");
@@ -95,7 +92,7 @@ public class QueryServlet extends HttpServlet {
   private String getcensusTableLink(String dataRow, String dataTablePrefix, String year) {
     return "https://data.census.gov/cedsci/table?tid=ACS"
         + (dataRow.substring(0,1).equals("K") 
-            ? "SE" 
+            ? "SE"
             : (tableNameToAbbrev.get(dataTablePrefix.substring(1)) + "1Y"))
         + year
         + "."
@@ -126,8 +123,8 @@ public class QueryServlet extends HttpServlet {
     
     String dataRow;
     if (year > 2013
-      && queryToDataRowPost2013.containsKey(action)
-      && queryToDataRowPost2013.get(action).containsKey(personType)) {
+        && queryToDataRowPost2013.containsKey(action)
+        && queryToDataRowPost2013.get(action).containsKey(personType)) {
       dataRow = queryToDataRowPost2013.get(action).get(personType);
     } else {
       dataRow = queryToDataRowGeneric.get(action).get(personType);

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -69,7 +69,7 @@ public class QueryServlet extends HttpServlet {
           "moved",
           /* TODO: K200701_005E + K200701_006E for state query,
           but actually have to add K200701_004E as well for county query */
-          ImmutableMap.of("all-ages", "S0201_119E,S0201_126E")); 
+          ImmutableMap.of("all-ages", "S0201_119E,S0201_126E"));
 
   Map<String, String> tableNameToAbbrev =
       ImmutableMap.of("profile", "DP", "spp", "SPP", "subject", "ST");
@@ -91,7 +91,7 @@ public class QueryServlet extends HttpServlet {
 
   private String getcensusTableLink(String dataRow, String dataTablePrefix, String year) {
     return "https://data.census.gov/cedsci/table?tid=ACS"
-        + (dataRow.substring(0,1).equals("K") 
+        + (dataRow.substring(0, 1).equals("K") 
             ? "SE"
             : (tableNameToAbbrev.get(dataTablePrefix.substring(1)) + "1Y"))
         + year
@@ -120,7 +120,7 @@ public class QueryServlet extends HttpServlet {
           "This query is not supported by census data. Try asking a more general one.");
       return;
     }
-    
+
     String dataRow;
     if (year > 2013
         && queryToDataRowPost2013.containsKey(action)

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -89,7 +89,7 @@ public class QueryServlet extends HttpServlet {
     return "N/A"; // should never reach this point
   }
 
-  private String getcensusTableLink(String dataRow, String dataTablePrefix, String year) {
+  private String getCensusTableLink(String dataRow, String dataTablePrefix, String year) {
     return "https://data.census.gov/cedsci/table?tid=ACS"
         + (dataRow.substring(0, 1).equals("K")
             ? "SE"
@@ -149,7 +149,7 @@ public class QueryServlet extends HttpServlet {
                 + (location.equals("state") ? "state:*" : "county:*&in=state:" + location)
                 + "&key=ea65020114ffc1e71e760341a0285f99e73eabbc");
 
-    String censusTableLink = getcensusTableLink(dataRow, dataTablePrefix, yearStr);
+    String censusTableLink = getCensusTableLink(dataRow, dataTablePrefix, yearStr);
 
     HttpURLConnection connection = (HttpURLConnection) fetchUrl.openConnection();
     connection.setRequestMethod("GET");

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -17,14 +17,14 @@ import javax.servlet.http.HttpServletResponse;
 public class QueryServlet extends HttpServlet {
 
   // Hardcoded initial choices for which lines of which data table are accessed
-  Map<String, Map<String, String>> queryToDataRow =
+  Map<String, Map<String, String>> queryToDataRowGeneric =
       ImmutableMap.of(
           "live",
           ImmutableMap.of(
               "under-18",
               "DP05_0019E",
               "over-18",
-              "DP05_0021E",
+              "DP05_0021E", /* still available for post-2013 if you do math */
               "all-ages",
               "DP05_0001E",
               "male",
@@ -41,39 +41,66 @@ public class QueryServlet extends HttpServlet {
               "S0201_182E",
               "female",
               "DP03_0013E"),
-          "moved",
+          "moved", /* TODO: All of these really should be two to three columns added together,
+          and then calculated as a percentage */
           ImmutableMap.of(
               "all-ages",
               "S0201_119E,S0201_126E",
               "male",
-              "S0701_C01_012E,S0701_C04_012E",
+              "S0701_C01_012E,S0701_C04_012E", 
               "female",
               "S0701_C01_013E,S0701_C04_013E"));
+
+  // After 2013, some queries have more data available
+  Map<String, Map<String, String>> queryToDataRowPost2013 =
+      ImmutableMap.of(
+          "live",
+          ImmutableMap.of(
+              "under-18",
+              "K200102_001E",
+              "all-ages",
+              "K200104_001E",
+              "male",
+              "K200101_002E",
+              "female",
+              "K200101_003E"),
+          "work",
+          ImmutableMap.of(
+              "all-ages",
+              "K202301_004E",
+              "over-18",
+              "K202301_004E"),
+          "moved",
+          ImmutableMap.of(
+              "all-ages",
+              "S0201_119E,S0201_126E", /* TODO: K200701_005E + K200701_006E for state query,
+              but actually have to add K200701_004E for county query */);
 
   Map<String, String> tableNameToAbbrev =
       ImmutableMap.of("profile", "DP", "spp", "SPP", "subject", "ST");
 
   // Depending on the beginning of the data table string, the query URL changes slightly
   private String getDataTableString(String tablePrefix) {
-    if (tablePrefix.substring(0, 1).equals("D")) {
-      return "profile?get=NAME,";
+    String firstChar = tablePrefix.substring(0, 1);
+    if (firstChar.equals("K")) {
+      return "";
+    } else if (firstChar.equals("D")) {
+      return "/profile";
     } else if (tablePrefix.substring(0, 5).equals("S0201")) {
-      return "spp?get=NAME,"; // Special case - different from the other S tables
-    } else if (tablePrefix.substring(0, 1).equals("S")) {
-      return "subject?get=NAME,";
+      return "/spp"; // Special case - different from the other S tables
+    } else if (firstChar.equals("S")) {
+      return "/subject";
     }
-    return ""; // should never reach this point
+    return "N/A"; // should never reach this point
   }
 
-  private String getcensusTableLink(String fetchUrlString, String dataTablePrefix, String year) {
+  private String getcensusTableLink(String dataRow, String dataTablePrefix, String year) {
     return "https://data.census.gov/cedsci/table?tid=ACS"
-        + tableNameToAbbrev.get(
-            fetchUrlString.substring(
-                fetchUrlString.indexOf(dataTablePrefix), fetchUrlString.indexOf("?")))
-        + "1Y"
+        + (dataRow.substring(0,1).equals("K") ? "SE" : 
+            (tableNameToAbbrev.get(dataTablePrefix.substring(1)) + "1Y"))
         + year
         + "."
-        + fetchUrlString.substring(fetchUrlString.indexOf(",") + 1, fetchUrlString.indexOf("_"));
+        + dataRow.substring(0, dataRow.indexOf("_"));
   }
 
   @Override
@@ -81,14 +108,15 @@ public class QueryServlet extends HttpServlet {
     String personType = request.getParameter("person-type");
     String action = request.getParameter("action");
     String location = request.getParameter("location");
-    String year = request.getParameter("year");
+    String yearStr = request.getParameter("year");
+    int year = Integer.parseInt(yearStr);
 
-    if (!queryToDataRow.containsKey(action)) {
+    if (!queryToDataRowGeneric.containsKey(action)) {
       // We don't have information on this action
       response.sendError(
           HttpServletResponse.SC_NOT_IMPLEMENTED, "We do not support this visualization yet.");
       return;
-    } else if (!queryToDataRow.get(action).containsKey(personType)) {
+    } else if (!queryToDataRowGeneric.get(action).containsKey(personType)) {
       // This action doesn't make sense with this type of person,
       // or the census doesn't keep data on it that we could find
       response.sendError(
@@ -96,26 +124,35 @@ public class QueryServlet extends HttpServlet {
           "This query is not supported by census data. Try asking a more general one.");
       return;
     }
+    
+    String dataRow;
+    if (year > 2013 && queryToDataRowPost2013.containsKey(action) && 
+      queryToDataRowPost2013.get(action).containsKey(personType)) {
+      dataRow = queryToDataRowPost2013.get(action).get(personType);
+    } else {
+      dataRow = queryToDataRowGeneric.get(action).get(personType);
+    }
 
-    String dataRow = queryToDataRow.get(action).get(personType);
     String dataTablePrefix = getDataTableString(dataRow);
-    if (dataTablePrefix.equals("")) {
+    if (dataTablePrefix.equals("N/A")) {
       response.sendError(
           HttpServletResponse.SC_NOT_IMPLEMENTED, "We do not support this visualization yet.");
     }
 
-    URL fetchUrl =
+    URL fetchUrl = /*BUG*/
         new URL(
             "https://api.census.gov/data/"
                 + year
-                + "/acs/acs1/"
+                + "/acs/"
+                + (dataRow.substring(0,1).equals("K") ? "acsse" : "acs1")
                 + dataTablePrefix
+                + "?get=NAME,"
                 + dataRow
                 + "&for="
                 + (location.equals("state") ? "state:*" : "county:*&in=state:" + location)
                 + "&key=ea65020114ffc1e71e760341a0285f99e73eabbc");
 
-    String censusTableLink = getcensusTableLink(fetchUrl.toString(), dataTablePrefix, year);
+    String censusTableLink = getcensusTableLink(dataRow, dataTablePrefix, yearStr);
 
     HttpURLConnection connection = (HttpURLConnection) fetchUrl.openConnection();
     connection.setRequestMethod("GET");

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -97,7 +97,8 @@ public class QueryServlet extends HttpServlet {
             : (tableNameToAbbrev.get(dataTablePrefix.substring(1)) + "1Y"))
         + year
         + "."
-        + dataRow.substring(0, (dataRow.contains("_") ? dataRow.indexOf("_") : dataRow.length() + 1));
+        + dataRow.substring(
+            0, (dataRow.contains("_") ? dataRow.indexOf("_") : dataRow.length() + 1));
   }
 
   @Override


### PR DESCRIPTION
https://censusviz.appspot.com/
Update backend's fetch URL creation to access data tables with information for more counties than previously.

The data tables being accessed cover all counties with population > 20,000, whereas the previous tables covered all counties > 65,000. However, these tables don't exist for all queries, and they only exist after 2013. For some queries, and all queries pre-2013, you can expect to see the same behavior as before. For a good number of queries post-2013, you should see many more (but not all) counties with data.