### PR TITLE
Substitute Saint with St. when accessing GeoJson

### DIFF
--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -270,7 +270,8 @@ async function displayCountyGeoJson(mapsData, description,
   map.data.forEach(function(feature) {
     map.data.setStyle((feature) => {
       return {
-        fillColor: colorScale(countyToPopMap[feature.j.name.replace("Saint", "St.")]).toString(),
+        fillColor: colorScale(
+            countyToPopMap[feature.j.name.replace('Saint', 'St.')]).toString(),
         fillOpacity: 0.5,
       };
     });
@@ -282,9 +283,11 @@ async function displayCountyGeoJson(mapsData, description,
       fillColor: maxColor,
     });
     let contentString;
-    if (countyToPopMap[event.feature.j.name.replace("Saint", "St.")] !== undefined) {
+    if (countyToPopMap[event.feature.j.name.replace('Saint', 'St.')] 
+        !== undefined) {
       contentString = '<p>' + event.feature.j.name +
-          '<p>' + description + ': ' + countyToPopMap[event.feature.j.name.replace("Saint", "St.")];
+          '<p>' + description + ': ' + 
+          countyToPopMap[event.feature.j.name.replace('Saint', 'St.')];
     } else {
       contentString = '<p>' + event.feature.j.name +
           '<p>Data not available';

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -258,7 +258,7 @@ async function displayCountyGeoJson(mapsData, description,
     center: {lat: stateInfo[stateNumber].lat, lng: stateInfo[stateNumber].lng},
   });
 
-  countyToPopMap = mapsData.map;
+  const countyToPopMap = mapsData.map;
   const maxPopulation = mapsData.maxValue;
   const minPopulation = mapsData.minValue;
   const minColor = chroma(color).brighten(2);
@@ -270,7 +270,7 @@ async function displayCountyGeoJson(mapsData, description,
   map.data.forEach(function(feature) {
     map.data.setStyle((feature) => {
       return {
-        fillColor: colorScale(countyToPopMap[feature.j.name]).toString(),
+        fillColor: colorScale(countyToPopMap[feature.j.name.replace("Saint", "St.")]).toString(),
         fillOpacity: 0.5,
       };
     });
@@ -282,9 +282,9 @@ async function displayCountyGeoJson(mapsData, description,
       fillColor: maxColor,
     });
     let contentString;
-    if (countyToPopMap[event.feature.j.name] !== undefined) {
+    if (countyToPopMap[event.feature.j.name.replace("Saint", "St.")] !== undefined) {
       contentString = '<p>' + event.feature.j.name +
-          '<p>' + description + ': ' + countyToPopMap[event.feature.j.name];
+          '<p>' + description + ': ' + countyToPopMap[event.feature.j.name.replace("Saint", "St.")];
     } else {
       contentString = '<p>' + event.feature.j.name +
           '<p>Data not available';

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -283,10 +283,10 @@ async function displayCountyGeoJson(mapsData, description,
       fillColor: maxColor,
     });
     let contentString;
-    if (countyToPopMap[event.feature.j.name.replace('Saint', 'St.')] 
-        !== undefined) {
+    if (countyToPopMap[event.feature.j.name.replace('Saint', 'St.')] !==
+        undefined) {
       contentString = '<p>' + event.feature.j.name +
-          '<p>' + description + ': ' + 
+          '<p>' + description + ': ' +
           countyToPopMap[event.feature.j.name.replace('Saint', 'St.')];
     } else {
       contentString = '<p>' + event.feature.j.name +


### PR DESCRIPTION
Substitute Saint with St. when accessing GeoJson data.

The census data uses "St.", but the GeoJson data uses "Saint". (The AmCharts data uses numbers in the backend, but displays "Saint" in the frontend.) Because of this, any counties with St./Saint in their name were not showing up in the GeoJson. I wanted to keep them as "Saint" to align with what AmCharts shows, so I only changed the name when directly accessing census data for the geoJson display function.