### PR TITLE
Reformat data in Java instead of JavaScript

### DIFF
--- a/src/main/java/DataFormatter.java
+++ b/src/main/java/DataFormatter.java
@@ -1,0 +1,125 @@
+package com.google.sps.data;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import java.io.InvalidObjectException;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.function.BiFunction;
+import java.util.List;
+import java.util.Map;
+
+// Reformats data from the QueryServlet according to a hard-coded list of instructions
+public class DataFormatter {
+
+  // Generic functions to combine numbers. Note that Math.round returns a long,
+  // but we can cast to int (max value ~2 billion) because our numbers
+  // will always be smaller than the U.S. population (~330 million)
+  private static BiFunction<Float, Float, Integer> add =
+      (Float a, Float b) -> (int) Math.round(a + b);
+  private static BiFunction<Float, Float, Integer> rightSubtract =
+      (Float a, Float b) -> (int) Math.round(a - b);
+  private static BiFunction<Float, Float, Integer> percent =
+      (Float a, Float b) -> (int) Math.round((a / 100.0) * b);
+
+  // Mapping data columns to the functions we want to execute on them --
+  // for example, if we are not able to access the population of children,
+  // instead we can do rightSubtract(total population, adult population)
+  private static Map<String, List<BiFunction>> dataRowToReformatFunction =
+      ImmutableMap.<String, List<BiFunction>>builder()
+          .put("DP05_0001E,DP05_0018E", ImmutableList.of(rightSubtract))
+          .put("S0201_119E,S0201_126E", ImmutableList.of(percent))
+          .put("K200104_001E,K200102_001E", ImmutableList.of(rightSubtract))
+          .put("S0701_C04_012E,S0701_C05_012E,S0701_C01_012E", ImmutableList.of(add, percent))
+          .put("S0701_C04_013E,S0701_C05_013E,S0701_C01_013E", ImmutableList.of(add, percent))
+          .put("S0201_125E,S0201_126E,S0201_119E", ImmutableList.of(add, percent))
+          .put("K200701_005E,K200701_006E", ImmutableList.of(add))
+          .put("K200701_004E,K200701_005E,K200701_006E", ImmutableList.of(add, add))
+          .put("S0201_124E,S0201_125E,S0201_126E,S0201_119E", ImmutableList.of(add, add, percent))
+          .put(
+              "S0701_C03_012E,S0701_C04_012E,S0701_C05_012E,S0701_C01_012E",
+              ImmutableList.of(add, add, percent))
+          .put(
+              "S0701_C03_013E,S0701_C04_013E,S0701_C05_013E,S0701_C01_013E",
+              ImmutableList.of(add, add, percent))
+          .put(
+              "P014001,P014021,P014022,P014042,P014043",
+              ImmutableList.of(rightSubtract, rightSubtract, rightSubtract, rightSubtract))
+          .build();
+
+  public static String reformatDataArray(String data, String dataIdentifier, boolean isCountyQuery)
+      throws InvalidObjectException {
+    if (!dataRowToReformatFunction.containsKey(dataIdentifier)) {
+      return data; // This data doesn't need reformatting
+    }
+    if ((dataRowToReformatFunction.get(dataIdentifier).size() + 1)
+        != dataIdentifier.split(",").length) {
+      // We should have enough functions listed to apply them to each group
+      // of two rows - (a, b) and then (their product, c), etc.
+      throw new InvalidObjectException(
+          "There aren't the right number of functions to apply to these data columns.");
+    }
+
+    // Convert from the census API's JSON string to a Java matrix
+    Gson gson = new Gson();
+    Type dataArrayType = new TypeToken<ArrayList<List<String>>>() {}.getType();
+    ArrayList<List<String>> originalDataArray = gson.fromJson(data, dataArrayType);
+    ArrayList<List<String>> newDataArray = new ArrayList<List<String>>();
+
+    // Create a new matrix to contain the reformatted data. Add in the the first column, which is
+    // the string identifier of the location, and the second column, the first numerical value
+    for (int i = 0; i < originalDataArray.size(); i++) {
+      List<String> originalDataRow = originalDataArray.get(i);
+      List<String> newDataRow = new ArrayList<String>();
+      newDataRow.add(originalDataRow.get(0));
+      newDataRow.add(originalDataRow.get(1));
+      newDataArray.add(newDataRow);
+    }
+
+    // Combine the original numbers, skipping the header row, by iterating over the functions
+    // given for these data columns. For each row, we successively combine the next datapoint
+    // with the previous result, finally resulting in one single fully-combined data point per row.
+    List<BiFunction> numberCombiners = dataRowToReformatFunction.get(dataIdentifier);
+    for (int i = 0; i < numberCombiners.size(); i++) { // Moving across columns combining numbers
+      BiFunction numberCombiner = numberCombiners.get(i);
+      for (int j = 1; j < originalDataArray.size(); j++) { // Moving down each row
+        List<String> originalDataRow = originalDataArray.get(j);
+        List<String> newDataRow = newDataArray.get(j);
+        if (newDataRow.get(1) == null || newDataRow.get(1).startsWith("-")) {
+          // Sometimes the census API returns missing or negative numbers by mistake;
+          // these get cleaned up in the JavaScript
+          newDataRow.set(1, "-1");
+        } else {
+          try {
+            int newValue =
+                (int)
+                    numberCombiner.apply(
+                        Float.parseFloat(newDataRow.get(1)), // Always replacing previous value
+                        Float.parseFloat(
+                            originalDataRow.get(i + 2))); // Moving along list of original values,
+            // skipping name column and the first number (already in newData)
+            newDataRow.set(1, String.valueOf(newValue)); // Replace previous value
+          } catch (NumberFormatException e) {
+            newDataRow.set(1, "-1");
+          }
+        }
+      }
+    }
+
+    // Add remaining identifier columns (state and county numbers)
+    for (int i = 0; i < originalDataArray.size(); i++) {
+      List<String> originalDataRow = originalDataArray.get(i);
+      List<String> newDataRow = newDataArray.get(i);
+      newDataRow.add(originalDataRow.get(numberCombiners.size() + 2));
+      if (isCountyQuery) {
+        newDataRow.add(originalDataRow.get(numberCombiners.size() + 3));
+      }
+    }
+
+    // Convert back into a JSON string for the JavaScript to read
+    String jsonData = gson.toJson(newDataArray);
+    return jsonData;
+  }
+}

--- a/src/main/java/DataFormatter.java
+++ b/src/main/java/DataFormatter.java
@@ -7,9 +7,9 @@ import com.google.gson.reflect.TypeToken;
 import java.io.InvalidObjectException;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.function.BiFunction;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 
 // Reformats data from the QueryServlet according to a hard-coded list of instructions
 public class DataFormatter {
@@ -17,7 +17,8 @@ public class DataFormatter {
   // Generic functions to combine numbers.
   private static BiFunction<Double, Double, Double> add = (Double a, Double b) -> a + b;
   private static BiFunction<Double, Double, Double> rightSubtract = (Double a, Double b) -> a - b;
-  private static BiFunction<Double, Double, Double> percent = (Double a, Double b) -> (a / 100.0) * b;
+  private static BiFunction<Double, Double, Double> percent =
+      (Double a, Double b) -> (a / 100.0) * b;
 
   // Mapping data columns to the functions we want to execute on them --
   // for example, if we are not able to access the population of children,
@@ -71,7 +72,7 @@ public class DataFormatter {
 
       // Moving across each row; we only iterate through the numbers, skipping
       // the initial identifier string and the last one or two state & county identifiers
-      for (int j = 1; j < originalDataRow.size() - (isCountyQuery ? 2 : 1); j++) { 
+      for (int j = 1; j < originalDataRow.size() - (isCountyQuery ? 2 : 1); j++) {
         String originalDataPoint = originalDataRow.get(j);
         if (originalDataPoint == null || originalDataPoint.startsWith("-")) {
           // Sometimes the census API returns missing or negative numbers by mistake;
@@ -99,12 +100,13 @@ public class DataFormatter {
         List<Double> newDataRow = newDataArray.get(j);
         // We always combine onto the first item in the data row, but combining it
         // the second, third, etc. item as we iterate 
-        Double newDataPoint = (double)numberCombiner.apply(newDataRow.get(0), newDataRow.get(i+1));
+        Double newDataPoint =
+            (double) numberCombiner.apply(newDataRow.get(0), newDataRow.get(i + 1));
         newDataRow.set(0, newDataPoint);
       }
     }
 
-    // Now we have the final number; create a new String array and copy in identifying 
+    // Now we have the final number; create a new String array and copy in identifying
     // info, plus the final number as a string
     ArrayList<List<String>> finalDataArray = new ArrayList<List<String>>();
     for (int i = 0; i < originalDataArray.size(); i++) {
@@ -119,7 +121,7 @@ public class DataFormatter {
         finalDataRow.add(String.valueOf(Math.round(numberDataRow.get(0)))); // final number
       }
 
-      // We have one fewer number combiner than we have numbers, so increasing 
+      // We have one fewer number combiner than we have numbers, so increasing
       // its size by two gives us the first non-number row
       finalDataRow.add(originalDataRow.get(numberCombiners.size() + 2)); // state ID
       if (isCountyQuery) {

--- a/src/main/java/DataFormatter.java
+++ b/src/main/java/DataFormatter.java
@@ -99,7 +99,7 @@ public class DataFormatter {
       for (int j = 0; j < originalDataArray.size() - 1; j++) { // Moving down through the rows
         List<Double> newDataRow = newDataArray.get(j);
         // We always combine onto the first item in the data row, but combining it
-        // the second, third, etc. item as we iterate 
+        // the second, third, etc. item as we iterate
         Double newDataPoint =
             (double) numberCombiner.apply(newDataRow.get(0), newDataRow.get(i + 1));
         newDataRow.set(0, newDataPoint);

--- a/src/main/java/DataFormatter.java
+++ b/src/main/java/DataFormatter.java
@@ -131,7 +131,6 @@ public class DataFormatter {
     }
 
     // Convert back into a JSON string for the JavaScript to read
-    String jsonData = gson.toJson(finalDataArray);
-    return jsonData;
+    return gson.toJson(finalDataArray);
   }
 }

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -7,14 +7,13 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.InvalidObjectException;
-import java.lang.Math;
 import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.function.BiFunction;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -220,7 +219,9 @@ public class QueryServlet extends HttpServlet {
       // An error occurred
       response.setStatus(HttpServletResponse.SC_BAD_GATEWAY);
       response.setContentType("application/json;");
-      response.getWriter().println(sendError("An error occurred while trying to retrieve census data."));
+      response
+          .getWriter()
+          .println(sendError("An error occurred while trying to retrieve census data."));
     } else {
       response.setStatus(HttpServletResponse.SC_OK);
       String data = "";
@@ -250,7 +251,9 @@ public class QueryServlet extends HttpServlet {
       } catch (InvalidObjectException e) {
         response.setStatus(HttpServletResponse.SC_BAD_GATEWAY);
         response.setContentType("application/json;");
-        response.getWriter().println(sendError("An error occurred while trying to retrieve census data."));
+        response
+            .getWriter()
+            .println(sendError("An error occurred while trying to retrieve census data."));
         return;
       }
       
@@ -269,43 +272,38 @@ public class QueryServlet extends HttpServlet {
   // will always be smaller than the U.S. population (~330 million)
   BiFunction<Float, Float, Integer> add = (Float a, Float b) -> (int)Math.round(a + b);
   BiFunction<Float, Float, Integer> rightSubtract = (Float a, Float b) -> (int)Math.round(a - b);
-  BiFunction<Float, Float, Integer> percent = (Float a, Float b) -> (int)Math.round((a/100.0) * b);
+  BiFunction<Float, Float, Integer> percent =
+      (Float a, Float b) -> (int)Math.round((a/100.0) * b);
 
   Map<String, List<BiFunction>> dataRowToReformatFunction =
       ImmutableMap.<String, List<BiFunction>>builder()
-      .put("DP05_0001E,DP05_0018E",
-          ImmutableList.of(rightSubtract))
-      .put("S0201_119E,S0201_126E",
-          ImmutableList.of(percent))
-      .put("K200104_001E,K200102_001E",
-          ImmutableList.of(rightSubtract))
-      .put("S0701_C04_012E,S0701_C05_012E,S0701_C01_012E",
-          ImmutableList.of(add, percent))
-      .put("S0701_C04_013E,S0701_C05_013E,S0701_C01_013E",
-          ImmutableList.of(add, percent))
-      .put("S0201_125E,S0201_126E,S0201_119E",
-          ImmutableList.of(add, percent))
-      .put("K200701_005E,K200701_006E",
-          ImmutableList.of(add))
-      .put("K200701_004E,K200701_005E,K200701_006E",
-          ImmutableList.of(add, add))
-      .put("S0201_124E,S0201_125E,S0201_126E,S0201_119E",
-          ImmutableList.of(add, add, percent))
-      .put("S0701_C03_012E,S0701_C04_012E,S0701_C05_012E,S0701_C01_012E",
-          ImmutableList.of(add, add, percent))
-      .put("S0701_C03_013E,S0701_C04_013E,S0701_C05_013E,S0701_C01_013E",
-          ImmutableList.of(add, add, percent))
-      .put("P014001,P014021,P014022,P014042,P014043",
-          ImmutableList.of(rightSubtract, rightSubtract, rightSubtract, rightSubtract))
-      .build();
+          .put("DP05_0001E,DP05_0018E", ImmutableList.of(rightSubtract))
+          .put("S0201_119E,S0201_126E", ImmutableList.of(percent))
+          .put("K200104_001E,K200102_001E", ImmutableList.of(rightSubtract))
+          .put("S0701_C04_012E,S0701_C05_012E,S0701_C01_012E", ImmutableList.of(add, percent))
+          .put("S0701_C04_013E,S0701_C05_013E,S0701_C01_013E", ImmutableList.of(add, percent))
+          .put("S0201_125E,S0201_126E,S0201_119E", ImmutableList.of(add, percent))
+          .put("K200701_005E,K200701_006E", ImmutableList.of(add))
+          .put("K200701_004E,K200701_005E,K200701_006E", ImmutableList.of(add, add))
+          .put("S0201_124E,S0201_125E,S0201_126E,S0201_119E", ImmutableList.of(add, add, percent))
+          .put(
+              "S0701_C03_012E,S0701_C04_012E,S0701_C05_012E,S0701_C01_012E",
+              ImmutableList.of(add, add, percent))
+          .put(
+              "S0701_C03_013E,S0701_C04_013E,S0701_C05_013E,S0701_C01_013E",
+              ImmutableList.of(add, add, percent))
+          .put(
+              "P014001,P014021,P014022,P014042,P014043",
+              ImmutableList.of(rightSubtract, rightSubtract, rightSubtract, rightSubtract))
+          .build();
 
-  private String reformatDataArray(String data, String dataIdentifier, boolean isCountyQuery) 
+  private String reformatDataArray(String data, String dataIdentifier, boolean isCountyQuery)
       throws InvalidObjectException {
     if (!dataRowToReformatFunction.containsKey(dataIdentifier)) {
       return data; // This data doesn't need reformatting
     }
-    if ((dataRowToReformatFunction.get(dataIdentifier).size() + 1) != 
-        dataIdentifier.split(",").length) {
+    if ((dataRowToReformatFunction.get(dataIdentifier).size() + 1)
+        != dataIdentifier.split(",").length) {
       // We should have enough functions listed to apply them to each group
       // of two rows - (a, b) and then (their product, c), etc.
       throw new InvalidObjectException(
@@ -314,11 +312,11 @@ public class QueryServlet extends HttpServlet {
 
     // Convert from the census API's JSON string to a Java matrix
     Gson gson = new Gson();
-    Type dataArrayType = new TypeToken<ArrayList<List<String>>>(){}.getType();
+    Type dataArrayType = new TypeToken<ArrayList<List<String>>>() {}.getType();
     ArrayList<List<String>> originalDataArray = gson.fromJson(data, dataArrayType);
     ArrayList<List<String>> newDataArray = new ArrayList<List<String>>();
 
-    // Add back the the first column, which is the string identifier of the location, 
+    // Add back the the first column, which is the string identifier of the location,
     // and the second column, the first numerical value
     for (int i = 0; i < originalDataArray.size(); i++) {
       List<String> originalDataRow = originalDataArray.get(i);
@@ -342,9 +340,12 @@ public class QueryServlet extends HttpServlet {
           newDataRow.set(1, "-1");
         } else {
           try {
-            int newValue = (int)numberCombiner.apply(
-                Float.parseFloat(newDataRow.get(1)), // Always replacing previous value
-                Float.parseFloat(originalDataRow.get(i+2))); // Moving along list of original values
+            int newValue = 
+                (int)
+                    numberCombiner.apply(
+                        Float.parseFloat(newDataRow.get(1)), // Always replacing previous value
+                        Float.parseFloat(
+                            originalDataRow.get(i+2))); // Moving along list of original values
             newDataRow.set(1, String.valueOf(newValue));
           } catch (NumberFormatException e) {
             newDataRow.set(1, "-1");
@@ -355,13 +356,13 @@ public class QueryServlet extends HttpServlet {
 
     // Add remaining identifier columns (state and county numbers)
     for (int i = 0; i < originalDataArray.size(); i++) {
-        List<String> originalDataRow = originalDataArray.get(i);
-        List<String> newDataRow = newDataArray.get(i);
-        newDataRow.add(originalDataRow.get(numberCombiners.size() + 2));
-        if (isCountyQuery) {
-          newDataRow.add(originalDataRow.get(numberCombiners.size() + 3));
-        }
+      List<String> originalDataRow = originalDataArray.get(i);
+      List<String> newDataRow = newDataArray.get(i);
+      newDataRow.add(originalDataRow.get(numberCombiners.size() + 2));
+      if (isCountyQuery) {
+        newDataRow.add(originalDataRow.get(numberCombiners.size() + 3));
       }
+    }
 
     // Convert back into a JSON string for the JavaScript to read
     String jsonData = gson.toJson(newDataArray);

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -49,7 +49,7 @@ public class QueryServlet extends HttpServlet {
               "S0201_182E",
               "female",
               "DP03_0013E"),
-          "moved", /* TODO: add row for county query */
+          "moved",
           ImmutableMap.of(
               "all-ages",
               "S0201_125E,S0201_126E,S0201_119E",
@@ -76,7 +76,6 @@ public class QueryServlet extends HttpServlet {
           "work",
           ImmutableMap.of("all-ages", "K202301_004E", "over-18", "K202301_004E"),
           "moved",
-          /* TODO: have to add K200701_004E as well for county query */
           ImmutableMap.of("all-ages", "K200701_005E,K200701_006E"));
 
   // Even more data available for population in 2010 when the decennial census happened
@@ -174,6 +173,19 @@ public class QueryServlet extends HttpServlet {
       dataRow = queryToDataRowDecennial.get(action).get(personType);
     }
 
+    // Queries about moving to counties instead of states need additional data
+    if (!location.equals("state") && action.equals("moved")) {
+      if (personType.equals("all-ages") && year > 2013) {
+        dataRow = "K200701_004E," + dataRow;
+      } else if (personType.equals("all-ages")) {
+        dataRow = "S0201_124E," + dataRow;
+      } else if (personType.equals("male")) {
+        dataRow = "S0701_C03_012E," + dataRow;
+      } else if (personType.equals("female")) {
+        dataRow = "S0701_C03_013E," + dataRow;
+      }
+    }
+
     String dataTablePrefix;
     try {
       dataTablePrefix = getDataTableString(dataRow);
@@ -269,6 +281,14 @@ public class QueryServlet extends HttpServlet {
           ImmutableList.of(add, percent))
       .put("K200701_005E,K200701_006E",
           ImmutableList.of(add))
+      .put("K200701_004E,K200701_005E,K200701_006E",
+          ImmutableList.of(add, add))
+      .put("S0201_124E,S0201_125E,S0201_126E,S0201_119E",
+          ImmutableList.of(add, add, percent))
+      .put("S0701_C03_012E,S0701_C04_012E,S0701_C05_012E,S0701_C01_012E",
+          ImmutableList.of(add, add, percent))
+      .put("S0701_C03_013E,S0701_C04_013E,S0701_C05_013E,S0701_C01_013E",
+          ImmutableList.of(add, add, percent))
       .build();
 
   private String reformatDataArray(String data, String dataIdentifier, boolean isCountyQuery) 

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -88,7 +88,11 @@ public class QueryServlet extends HttpServlet {
               "male",
               "P012002",
               "female",
-              "P012026")); /* TODO: can't do over/under-18 until after adding is implemented */
+              "P012026",
+              "under-18",
+              "P014001,P014021,P014022,P014042,P014043",
+              "over-18",
+              "P010001"));
 
   Map<String, String> tableNameToAbbrev =
       ImmutableMap.of("profile", "DP", "spp", "SPP", "subject", "ST");
@@ -291,6 +295,8 @@ public class QueryServlet extends HttpServlet {
           ImmutableList.of(add, add, percent))
       .put("S0701_C03_013E,S0701_C04_013E,S0701_C05_013E,S0701_C01_013E",
           ImmutableList.of(add, add, percent))
+      .put("P014001,P014021,P014022,P014042,P014043",
+          ImmutableList.of(rightSubtract, rightSubtract, rightSubtract, rightSubtract))
       .build();
 
   private String reformatDataArray(String data, String dataIdentifier, boolean isCountyQuery) 

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -351,7 +351,7 @@ public class QueryServlet extends HttpServlet {
                         Float.parseFloat(newDataRow.get(1)), // Always replacing previous value
                         Float.parseFloat(
                             originalDataRow.get(i + 2))); // Moving along list of original values,
-             // skipping name column and the first number (already in newData)
+            // skipping name column and the first number (already in newData)
             newDataRow.set(1, String.valueOf(newValue)); // Replace previous value
           } catch (NumberFormatException e) {
             newDataRow.set(1, "-1");

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -30,9 +30,9 @@ public class QueryServlet extends HttpServlet {
           "live",
           ImmutableMap.of(
               "under-18",
-              "DP05_0019E",
+              "DP05_0001E,DP05_0018E",
               "over-18",
-              "DP05_0021E",
+              "DP05_0018E",
               "all-ages",
               "DP05_0001E",
               "male",
@@ -269,6 +269,8 @@ public class QueryServlet extends HttpServlet {
 
   Map<String, List<BiFunction>> dataRowToReformatFunction =
       ImmutableMap.<String, List<BiFunction>>builder()
+      .put("DP05_0001E,DP05_0018E",
+          ImmutableList.of(rightSubtract))
       .put("S0201_119E,S0201_126E",
           ImmutableList.of(percent))
       .put("K200104_001E,K200102_001E",

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -1,4 +1,3 @@
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonObject;
 import com.google.sps.data.DataFormatter;
@@ -8,8 +7,6 @@ import java.io.InputStreamReader;
 import java.io.InvalidObjectException;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -242,7 +242,7 @@ public class QueryServlet extends HttpServlet {
     if (!dataRowToReformatFunction.containsKey(dataIdentifier)) {
       return data; // This data doesn't need reformatting
     }
-    if ((dataRowToReformatFunction.get(dataIdentifier).size() + (isCountyQuery ? 2 : 1)) != 
+    if ((dataRowToReformatFunction.get(dataIdentifier).size() + 1) != 
         dataIdentifier.split(",").length) {
       // We should have enough functions listed to apply them to each group
       // of two rows - (a, b) and then (their product, c), etc.
@@ -297,7 +297,7 @@ public class QueryServlet extends HttpServlet {
         List<String> newDataRow = newDataArray.get(i);
         newDataRow.add(originalDataRow.get(numberCombiners.size() + 2));
         if (isCountyQuery) {
-          newDataRow.add(originalDataRow.get(numberCombiners.size() + 1));
+          newDataRow.add(originalDataRow.get(numberCombiners.size() + 3));
         }
       }
 

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -270,10 +270,10 @@ public class QueryServlet extends HttpServlet {
 
   // Math.round returns a long, but we can cast to int (max value ~2 billion) because our numbers
   // will always be smaller than the U.S. population (~330 million)
-  BiFunction<Float, Float, Integer> add = (Float a, Float b) -> (int)Math.round(a + b);
-  BiFunction<Float, Float, Integer> rightSubtract = (Float a, Float b) -> (int)Math.round(a - b);
+  BiFunction<Float, Float, Integer> add = (Float a, Float b) -> (int) Math.round(a + b);
+  BiFunction<Float, Float, Integer> rightSubtract = (Float a, Float b) -> (int) Math.round(a - b);
   BiFunction<Float, Float, Integer> percent =
-      (Float a, Float b) -> (int)Math.round((a/100.0) * b);
+      (Float a, Float b) -> (int) Math.round((a/100.0) * b);
 
   Map<String, List<BiFunction>> dataRowToReformatFunction =
       ImmutableMap.<String, List<BiFunction>>builder()
@@ -340,12 +340,12 @@ public class QueryServlet extends HttpServlet {
           newDataRow.set(1, "-1");
         } else {
           try {
-            int newValue = 
+            int newValue =
                 (int)
                     numberCombiner.apply(
                         Float.parseFloat(newDataRow.get(1)), // Always replacing previous value
                         Float.parseFloat(
-                            originalDataRow.get(i+2))); // Moving along list of original values
+                            originalDataRow.get(i + 2))); // Moving along list of original values
             newDataRow.set(1, String.valueOf(newValue));
           } catch (NumberFormatException e) {
             newDataRow.set(1, "-1");

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -273,7 +273,7 @@ public class QueryServlet extends HttpServlet {
   BiFunction<Float, Float, Integer> add = (Float a, Float b) -> (int) Math.round(a + b);
   BiFunction<Float, Float, Integer> rightSubtract = (Float a, Float b) -> (int) Math.round(a - b);
   BiFunction<Float, Float, Integer> percent =
-      (Float a, Float b) -> (int) Math.round((a/100.0) * b);
+      (Float a, Float b) -> (int) Math.round((a / 100.0) * b);
 
   Map<String, List<BiFunction>> dataRowToReformatFunction =
       ImmutableMap.<String, List<BiFunction>>builder()

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -256,7 +256,7 @@ public class QueryServlet extends HttpServlet {
             .println(sendError("An error occurred while trying to retrieve census data."));
         return;
       }
-      
+
       JsonObject jsonResponse = new JsonObject();
       jsonResponse.addProperty("censusData", formattedData);
       jsonResponse.addProperty("tableLink", censusTableLink);

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -1,19 +1,16 @@
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.gson.Gson;
 import com.google.gson.JsonObject;
-import com.google.gson.reflect.TypeToken;
+import com.google.sps.data.DataFormatter;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.InvalidObjectException;
-import java.lang.reflect.Type;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiFunction;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -247,7 +244,7 @@ public class QueryServlet extends HttpServlet {
 
       String formattedData;
       try {
-        formattedData = reformatDataArray(data, dataRow, !location.equals("state"));
+        formattedData = DataFormatter.reformatDataArray(data, dataRow, !location.equals("state"));
       } catch (InvalidObjectException e) {
         response.setStatus(HttpServletResponse.SC_BAD_GATEWAY);
         response.setContentType("application/json;");
@@ -263,115 +260,5 @@ public class QueryServlet extends HttpServlet {
       response.setContentType("application/json;");
       response.getWriter().println(jsonResponse.toString());
     }
-  }
-
-  // Some data arrays need reformatting (columns added together, etc.) before they can be
-  // visualized.
-
-  // Generic functions to combine numbers. Note that Math.round returns a long,
-  // but we can cast to int (max value ~2 billion) because our numbers
-  // will always be smaller than the U.S. population (~330 million)
-  BiFunction<Float, Float, Integer> add = (Float a, Float b) -> (int) Math.round(a + b);
-  BiFunction<Float, Float, Integer> rightSubtract = (Float a, Float b) -> (int) Math.round(a - b);
-  BiFunction<Float, Float, Integer> percent =
-      (Float a, Float b) -> (int) Math.round((a / 100.0) * b);
-
-  // Mapping data columns to the functions we want to execute on them --
-  // for example, if we are not able to access the population of children,
-  // instead we can do rightSubtract(total population, adult population)
-  Map<String, List<BiFunction>> dataRowToReformatFunction =
-      ImmutableMap.<String, List<BiFunction>>builder()
-          .put("DP05_0001E,DP05_0018E", ImmutableList.of(rightSubtract))
-          .put("S0201_119E,S0201_126E", ImmutableList.of(percent))
-          .put("K200104_001E,K200102_001E", ImmutableList.of(rightSubtract))
-          .put("S0701_C04_012E,S0701_C05_012E,S0701_C01_012E", ImmutableList.of(add, percent))
-          .put("S0701_C04_013E,S0701_C05_013E,S0701_C01_013E", ImmutableList.of(add, percent))
-          .put("S0201_125E,S0201_126E,S0201_119E", ImmutableList.of(add, percent))
-          .put("K200701_005E,K200701_006E", ImmutableList.of(add))
-          .put("K200701_004E,K200701_005E,K200701_006E", ImmutableList.of(add, add))
-          .put("S0201_124E,S0201_125E,S0201_126E,S0201_119E", ImmutableList.of(add, add, percent))
-          .put(
-              "S0701_C03_012E,S0701_C04_012E,S0701_C05_012E,S0701_C01_012E",
-              ImmutableList.of(add, add, percent))
-          .put(
-              "S0701_C03_013E,S0701_C04_013E,S0701_C05_013E,S0701_C01_013E",
-              ImmutableList.of(add, add, percent))
-          .put(
-              "P014001,P014021,P014022,P014042,P014043",
-              ImmutableList.of(rightSubtract, rightSubtract, rightSubtract, rightSubtract))
-          .build();
-
-  private String reformatDataArray(String data, String dataIdentifier, boolean isCountyQuery)
-      throws InvalidObjectException {
-    if (!dataRowToReformatFunction.containsKey(dataIdentifier)) {
-      return data; // This data doesn't need reformatting
-    }
-    if ((dataRowToReformatFunction.get(dataIdentifier).size() + 1)
-        != dataIdentifier.split(",").length) {
-      // We should have enough functions listed to apply them to each group
-      // of two rows - (a, b) and then (their product, c), etc.
-      throw new InvalidObjectException(
-          "There aren't the right number of functions to apply to these data columns.");
-    }
-
-    // Convert from the census API's JSON string to a Java matrix
-    Gson gson = new Gson();
-    Type dataArrayType = new TypeToken<ArrayList<List<String>>>() {}.getType();
-    ArrayList<List<String>> originalDataArray = gson.fromJson(data, dataArrayType);
-    ArrayList<List<String>> newDataArray = new ArrayList<List<String>>();
-
-    // Create a new matrix to contain the reformatted data. Add in the the first column, which is
-    // the string identifier of the location, and the second column, the first numerical value
-    for (int i = 0; i < originalDataArray.size(); i++) {
-      List<String> originalDataRow = originalDataArray.get(i);
-      List<String> newDataRow = new ArrayList<String>();
-      newDataRow.add(originalDataRow.get(0));
-      newDataRow.add(originalDataRow.get(1));
-      newDataArray.add(newDataRow);
-    }
-
-    // Combine the original numbers, skipping the header row, by iterating over the functions
-    // given for these data columns. For each row, we successively combine the next datapoint
-    // with the previous result, finally resulting in one single fully-combined data point per row.
-    List<BiFunction> numberCombiners = dataRowToReformatFunction.get(dataIdentifier);
-    for (int i = 0; i < numberCombiners.size(); i++) { // Moving across columns combining numbers
-      BiFunction numberCombiner = numberCombiners.get(i);
-      for (int j = 1; j < originalDataArray.size(); j++) { // Moving down each row
-        List<String> originalDataRow = originalDataArray.get(j);
-        List<String> newDataRow = newDataArray.get(j);
-        if (newDataRow.get(1) == null || newDataRow.get(1).startsWith("-")) {
-          // Sometimes the census API returns missing or negative numbers by mistake;
-          // these get cleaned up in the JavaScript
-          newDataRow.set(1, "-1");
-        } else {
-          try {
-            int newValue =
-                (int)
-                    numberCombiner.apply(
-                        Float.parseFloat(newDataRow.get(1)), // Always replacing previous value
-                        Float.parseFloat(
-                            originalDataRow.get(i + 2))); // Moving along list of original values,
-            // skipping name column and the first number (already in newData)
-            newDataRow.set(1, String.valueOf(newValue)); // Replace previous value
-          } catch (NumberFormatException e) {
-            newDataRow.set(1, "-1");
-          }
-        }
-      }
-    }
-
-    // Add remaining identifier columns (state and county numbers)
-    for (int i = 0; i < originalDataArray.size(); i++) {
-      List<String> originalDataRow = originalDataArray.get(i);
-      List<String> newDataRow = newDataArray.get(i);
-      newDataRow.add(originalDataRow.get(numberCombiners.size() + 2));
-      if (isCountyQuery) {
-        newDataRow.add(originalDataRow.get(numberCombiners.size() + 3));
-      }
-    }
-
-    // Convert back into a JSON string for the JavaScript to read
-    String jsonData = gson.toJson(newDataArray);
-    return jsonData;
   }
 }

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -351,7 +351,7 @@ public class QueryServlet extends HttpServlet {
                         Float.parseFloat(newDataRow.get(1)), // Always replacing previous value
                         Float.parseFloat(
                             originalDataRow.get(i + 2))); // Moving along list of original values,
-                            // skipping name column and the first number (already in newData)
+             // skipping name column and the first number (already in newData)
             newDataRow.set(1, String.valueOf(newValue)); // Replace previous value
           } catch (NumberFormatException e) {
             newDataRow.set(1, "-1");

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -154,48 +154,13 @@ function createDataArray(censusDataArray, isCountyQuery) {
   // first row is headers
   const regionIndex = censusDataArray[0].indexOf('state');
   censusDataArray = censusDataArray.slice(1); // get rid of header row
-  // Check to see if an extra calculation for percentages is needed
-  if (checkPercentage(censusDataArray[0], isCountyQuery)) {
-    censusDataArray.forEach((location) => {
-      vizDataArray.push({
-        id: getLocationId(location, isCountyQuery, regionIndex),
-        locationName: location[0],
-        value: percentToTotal(location[1], location[2])});
+  censusDataArray.forEach((location) => {
+    vizDataArray.push({
+      id: getLocationId(location, isCountyQuery, regionIndex),
+      locationName: location[0],
+      value: location[1]});
     });
-  } else {
-    censusDataArray.forEach((location) => {
-      vizDataArray.push({
-        id: getLocationId(location, isCountyQuery, regionIndex),
-        locationName: location[0],
-        value: location[1]});
-    });
-  }
   return vizDataArray;
-}
-
-// percentToTotal takes in the total number of people in a category
-// and the percentage and returns the total
-function percentToTotal(totalNumber, percentage) {
-  return Math.round((totalNumber/100) * percentage);
-}
-
-// checkPercentage() Takes in the header of a census query and returns
-// whether or not the total needs to be calculated using the
-// percentToTotal() function
-function checkPercentage(headerColumn, isCountyQuery) {
-  // Queries that are percentages will have two columns of numbers instead
-  // of one, where one is a total number and one is a number between 0 and 100
-  // (which represents the percentage of the total).
-  // County queries always have one more column (to list both county and state)
-  if ((!isCountyQuery && headerColumn.length !== 4) ||
-      (isCountyQuery && headerColumn.length !== 5)) {
-    return false;
-  }
-  const firstNum = Number(headerColumn[1]);
-  const secondNum = Number(headerColumn[2]);
-  return !(isNaN(firstNum) || isNaN(secondNum)) &&
-      ((firstNum > 100 && secondNum >= 0 && secondNum <= 100) ||
-      (secondNum > 100 && firstNum >= 0 && firstNum <= 100));
 }
 
 // Returns an object containing all of the relevant data in order


### PR DESCRIPTION
Do data reformatting (percentage calculations etc.) in Java, and add support for additional kinds of reformatting (adding, subtracting, and chaining calculations). Client experience remains the same but data is more precise and there is more detailed data available for some queries.

I left it all in the same file right now for ease of use, but if it seems appropriate to break it out into a second Java file, I can do that as well. Edit: it is now in its own file.