### PR TITLE
Caching queries

### DIFF
--- a/.htmllintrc
+++ b/.htmllintrc
@@ -24,8 +24,7 @@
     "text-ignore-regex": false,
     "tag-bans": [
         "style",
-        "b",
-        "i"
+        "b"
     ],
     "tag-close": true,
     "tag-name-lowercase": true,

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,11 @@
       <version>2.8.6</version>
     </dependency>
     <dependency>
+      <groupId>com.googlecode.objectify</groupId>
+      <artifactId>objectify</artifactId>
+      <version>6.0.6</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>29.0-jre</version>

--- a/src/main/java/CensusData.java
+++ b/src/main/java/CensusData.java
@@ -1,16 +1,29 @@
+package com.google.sps.data;
+
 import com.googlecode.objectify.annotation.Cache;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
-import com.googlecode.objectify.annotation.Index;
 
 @Entity
 @Cache
 public class CensusData {
-    @Id String id;
-    @Index String data;
+  @Id String query;
+  String data;
+  String tableLink;
 
-    public CensusData(String id, String data) {
-        this.id = queryId;
-        this.data = data;
-    }
+  private CensusData() {}
+
+  public CensusData(String query, String data, String tableLink) {
+    this.query = query;
+    this.data = data;
+    this.tableLink = tableLink;
+  }
+
+  public String getData() {
+    return data;
+  }
+
+  public String getTableLink() {
+    return tableLink;
+  }
 }

--- a/src/main/java/CensusData.java
+++ b/src/main/java/CensusData.java
@@ -1,0 +1,16 @@
+import com.googlecode.objectify.annotation.Cache;
+import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Id;
+import com.googlecode.objectify.annotation.Index;
+
+@Entity
+@Cache
+public class CensusData {
+    @Id String id;
+    @Index String data;
+
+    public CensusData(String id, String data) {
+        this.id = queryId;
+        this.data = data;
+    }
+}

--- a/src/main/java/ObjectifyInit.java
+++ b/src/main/java/ObjectifyInit.java
@@ -1,0 +1,24 @@
+import com.google.cloud.datastore.DatastoreOptions;
+import com.googlecode.objectify.ObjectifyFactory;
+import com.googlecode.objectify.ObjectifyService;
+import com.google.sps.data.CensusData;
+import javax.servlet.ServletContextListener;
+import javax.servlet.ServletContextEvent;
+
+
+public class ObjectifyInit implements ServletContextListener {
+	public void contextInitialized(ServletContextEvent event) {
+		ObjectifyService.init(new ObjectifyFactory(
+      DatastoreOptions.newBuilder()
+        .setHost("http://localhost:8484")
+        .setProjectId("censusviz")
+        .build()
+        .getService()
+	  ));
+    ObjectifyService.register(CensusData.class);
+	}
+
+	public void contextDestroyed(ServletContextEvent event) {
+    // App Engine does not currently invoke this method.
+  }
+}

--- a/src/main/java/ObjectifyInit.java
+++ b/src/main/java/ObjectifyInit.java
@@ -15,6 +15,8 @@ public class ObjectifyInit implements ServletContextListener {
                 .setProjectId("censusviz")
                 .build()
                 .getService()));
+    // To deploy, everything above this must be commented out
+    // and replaced with only ObjectifyService.init();
     ObjectifyService.register(CensusData.class);
   }
 

--- a/src/main/java/ObjectifyInit.java
+++ b/src/main/java/ObjectifyInit.java
@@ -1,21 +1,21 @@
 import com.google.cloud.datastore.DatastoreOptions;
+import com.google.sps.data.CensusData;
 import com.googlecode.objectify.ObjectifyFactory;
 import com.googlecode.objectify.ObjectifyService;
-import com.google.sps.data.CensusData;
-import javax.servlet.ServletContextListener;
 import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
 
 
 public class ObjectifyInit implements ServletContextListener {
   public void contextInitialized(ServletContextEvent event) {
-    ObjectifyService.init(new ObjectifyFactory(
-    DatastoreOptions.newBuilder()
-    // This host is used for testing using a datastore emulator
-    .setHost("http://localhost:8484")
-    .setProjectId("censusviz")
-    .build()
-    .getService()
-    ));
+    ObjectifyService.init(
+        new ObjectifyFactory(
+            DatastoreOptions.newBuilder()
+                // This host is used for testing using a datastore emulator
+                .setHost("http://localhost:8484")
+                .setProjectId("censusviz")
+                .build()
+                .getService()));
     ObjectifyService.register(CensusData.class);
   }
 

--- a/src/main/java/ObjectifyInit.java
+++ b/src/main/java/ObjectifyInit.java
@@ -7,18 +7,19 @@ import javax.servlet.ServletContextEvent;
 
 
 public class ObjectifyInit implements ServletContextListener {
-	public void contextInitialized(ServletContextEvent event) {
-		ObjectifyService.init(new ObjectifyFactory(
-      DatastoreOptions.newBuilder()
-        .setHost("http://localhost:8484")
-        .setProjectId("censusviz")
-        .build()
-        .getService()
-	  ));
+  public void contextInitialized(ServletContextEvent event) {
+    ObjectifyService.init(new ObjectifyFactory(
+    DatastoreOptions.newBuilder()
+    // This host is used for testing using a datastore emulator
+    .setHost("http://localhost:8484")
+    .setProjectId("censusviz")
+    .build()
+    .getService()
+    ));
     ObjectifyService.register(CensusData.class);
-	}
+  }
 
-	public void contextDestroyed(ServletContextEvent event) {
+  public void contextDestroyed(ServletContextEvent event) {
     // App Engine does not currently invoke this method.
   }
 }

--- a/src/main/java/ObjectifyInit.java
+++ b/src/main/java/ObjectifyInit.java
@@ -5,7 +5,6 @@ import com.googlecode.objectify.ObjectifyService;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
-
 public class ObjectifyInit implements ServletContextListener {
   public void contextInitialized(ServletContextEvent event) {
     ObjectifyService.init(

--- a/src/main/java/QueryServlet.java
+++ b/src/main/java/QueryServlet.java
@@ -1,24 +1,20 @@
-import com.googlecode.objectify.ObjectifyService;
-import com.google.common.collect.ImmutableList;
+import static com.googlecode.objectify.ObjectifyService.ofy;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonObject;
-import com.google.sps.data.DataFormatter;
 import com.google.sps.data.CensusData;
+import com.google.sps.data.DataFormatter;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.InvalidObjectException;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import static com.googlecode.objectify.ObjectifyService.ofy;
 
 /** Servlet that handles census queries from users */
 @WebServlet("/query")

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app>
+    <servlet>
+        <servlet-name>QueryServlet</servlet-name>
+        <servlet-class>QueryServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>QueryServlet</servlet-name>
+        <url-pattern>/query</url-pattern>
+    </servlet-mapping>
+    <filter>
+        <filter-name>ObjectifyFilter</filter-name>
+        <filter-class>com.googlecode.objectify.ObjectifyFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>ObjectifyFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
+    <listener>
+        <listener-class>ObjectifyInit</listener-class>
+    </listener>
+</web-app>

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -57,13 +57,18 @@ function displayAmChartsMap(data, description, geoData, color) {
   chart.geodata = geoData;
   // Add button to zoom out
   const home = chart.chartContainer.createChild(am4core.Button);
-  home.label.text = 'Home';
+  home.label.text = 'Reset zoom level';
   home.align = 'right';
   home.events.on('hit', function(ev) {
     chart.goHome();
   });
 
-  chart.projection = new am4maps.projections.AlbersUsa();
+  // Albers projection for state level, Mercator for county level
+  if (data[0].id.indexOf('US') !== -1) {
+    chart.projection = new am4maps.projections.AlbersUsa();
+  } else {
+    chart.projection = new am4maps.projections.Mercator();
+  }
   const polygonSeries = chart.series.push(new am4maps.MapPolygonSeries());
 
   // Set min/max fill color for each area

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -22,7 +22,7 @@
 <body onload="registerServiceWorker(); createStateDropdownList();">
   <main>
     <div id="header">
-      <h1>Census Viz
+      <h1><a href="/">Census Viz</a>
         <div class="tooltip">
           <a target="_blank" rel="noopener" href="http://go/censusviz-feedback">
             <i class="material-icons" id="feedback" href="cnn.com">feedback</i>

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -36,6 +36,11 @@ select:focus {
   padding-left: 30px;
 }
 
+#header a:-webkit-any-link {
+  color: black;
+  text-decoration: none;
+}
+
 .material-icons {
   float: right;
   font-size: 125%;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -47,10 +47,6 @@ select:focus {
   line-height: .5;
 }
 
-#feedback {
-  color: black;
-}
-
 .tooltip {
   display: inline;
 }


### PR DESCRIPTION
Implement caching

Using [Objectify](https://github.com/objectify/objectify/wiki), a datastore API that also provides a global cache shared by all running instances of the application. By default all entities stay in the cache until it is full, not sure how entities are chosen to be evicted once cache is full.

Wasn't able to test speed improvements since this isn't deployed, but a local version can be ran with a datastore emulator that's started with
```console
gcloud beta emulators datastore start --host-port=localhost:8484
```

Also
- Switched to Mercator projection for state maps
- Relabeled reset zoom button