### PR TITLE
Allow user to enter non-state locations

### DIFF
--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -30,7 +30,7 @@ async function displayVisualization(censusDataArray, description,
   const geoData = await getGeoData(locationInfo, isCountyQuery);
   // Put all necessary data in the cache
   localStorage.setItem('geoData', JSON.stringify(geoData));
-  localStorage.setItem('location', locationInfo);
+  localStorage.setItem('location', JSON.stringify(locationInfo));
   localStorage.setItem('description', description);
   setStyle(isCountyQuery);
   const amChartsData = createDataArray(censusDataArray, isCountyQuery);
@@ -331,7 +331,7 @@ function changeColor(colorParam) {
   const cacheMapsData = JSON.parse(localStorage.getItem('mapsData'));
   const cacheGeoData = JSON.parse(localStorage.getItem('geoData'));
   const cacheAmCharts = JSON.parse(localStorage.getItem('amChartsData'));
-  const cacheLocation = localStorage.getItem('location');
+  const cacheLocation = JSON.parse(localStorage.getItem('location'));
   const cacheDescription = localStorage.getItem('description');
   // map is undefined on a state query, so check to be sure that
   // it is undefined before calling displayCountyGeoJson.

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -339,7 +339,7 @@ function changeColor(colorParam) {
     displayCountyGeoJson(cacheMapsData, cacheDescription, cacheLocation,
       cacheGeoData, color);
   }
-  displayAmChartsMap(cacheAmCharts, cacheDescription, cacheGeoData, color);
+  displayAmChartsMap(cacheAmCharts, cacheLocation, cacheDescription, cacheGeoData, color);
 }
 
 // Draw data table using Visualization API

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -41,10 +41,12 @@ async function displayVisualization(censusDataArray, description,
       localStorage.setItem(
           'mapsData',
           JSON.stringify(mapsData));
-      displayAmChartsMap(amChartsData, locationInfo, description, geoData, color);
+      displayAmChartsMap(
+          amChartsData, locationInfo, description, geoData, color);
       displayCountyGeoJson(mapsData, description, locationInfo, geoData, color);
   } else {
-      displayAmChartsMap(amChartsData, locationInfo, description, geoData, color);
+      displayAmChartsMap(
+          amChartsData, locationInfo, description, geoData, color);
   }
   document.getElementById('more-info').innerText = '';
 }

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -339,7 +339,8 @@ function changeColor(colorParam) {
     displayCountyGeoJson(cacheMapsData, cacheDescription, cacheLocation,
       cacheGeoData, color);
   }
-  displayAmChartsMap(cacheAmCharts, cacheLocation, cacheDescription, cacheGeoData, color);
+  displayAmChartsMap(cacheAmCharts, cacheLocation, cacheDescription,
+      cacheGeoData, color);
 }
 
 // Draw data table using Visualization API

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -2,7 +2,8 @@
 // loaded for the location.
 async function getGeoData(locationInfo, isCountyQuery) {
   if (isCountyQuery) {
-    const abbrev = stateInfo[locationInfo.number].ISO.replace(/US-/, '').toLowerCase();
+    const abbrev =
+        stateInfo[locationInfo.number].ISO.replace(/US-/, '').toLowerCase();
     if (!stateInfo[locationInfo.number].geoJsonLoaded) {
       await new Promise((resolve, reject) => {
         const script = document.createElement('script');
@@ -37,7 +38,9 @@ async function displayVisualization(censusDataArray, description,
   drawTable(amChartsData, description, isCountyQuery);
   if (isCountyQuery) {
       const mapsData = getMapsData(censusDataArray);
-      localStorage.setItem('mapsData', JSON.stringify(mapsData));
+      localStorage.setItem(
+          'mapsData',
+          JSON.stringify(mapsData));
       displayAmChartsMap(amChartsData, locationInfo, description, geoData, color);
       displayCountyGeoJson(mapsData, description, locationInfo, geoData, color);
   } else {
@@ -53,7 +56,7 @@ function displayAmChartsMap(data, locationInfo, description, geoData, color) {
   chart.height = 550;
   chart.homeGeoPoint = {
     latitude: locationInfo.lat,
-    longitude: locationInfo.lng
+    longitude: locationInfo.lng,
   };
   chart.zoomControl = new am4maps.ZoomControl();
   // only allow zooming with buttons

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -47,7 +47,7 @@
             Depending on your question, we choose the census data with the most
             information available. Most of our data come from the annual
             American Community Survey; if you ask about a year ending
-            in 0, you'll get information from the larger Decennial Survey 
+            in 0, you'll get information from the larger Decennial Survey
             instead. Both surveys provide estimates based on a sample
             population; if you don't see any data for a county, it's because
             the sample size was too small for an accurate estimate.
@@ -92,7 +92,7 @@
           </input>
 
           <input type="list" list="location" name="location" id="location-list"
-              autocomplete="off" required 
+              autocomplete="off" required
               onfocus="storeValueAndEmpty('location')"
               onfocusout="replaceValueIfEmpty('location')"
               value="each U.S. state">

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -14,7 +14,7 @@
   <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
   <script src="state-info.js"></script>
   <script src="data-visualization.js"></script>
-  <script src="user-location.js"></script>
+  <script src="location-finding.js"></script>
   <script src="query-control.js"></script>
   <link rel="stylesheet" href="style.css">
   <link id="favicon" rel="shortcut icon" href="./images/favicon.ico">

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -14,8 +14,8 @@
   <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
   <script src="state-info.js"></script>
   <script src="data-visualization.js"></script>
-  <script src="query-control.js"></script>
   <script src="user-location.js"></script>
+  <script src="query-control.js"></script>
   <link rel="stylesheet" href="style.css">
   <link id="favicon" rel="shortcut icon" href="./images/favicon.ico">
 </head>
@@ -89,7 +89,7 @@
           </input>
 
           <input type="list" list="location" name="location" id="location-list"
-              autocomplete="off" required onkeyup="validateInput('location')"
+              autocomplete="off" required 
               onfocus="storeValueAndEmpty('location')"
               onfocusout="replaceValueIfEmpty('location')"
               value="each U.S. state">

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -36,17 +36,21 @@
             Census data by creating custom visualizations to answer your
             questions about America.
             <br><br>
-            To use Census Viz, select an option
-            from each dropdown list and click the green Go button. You can
-            also start typing in any dropdown box to filter the options you'll
-            see. You can mix and match between the lists to get answers to
-            many different questions.
+            To use Census Viz, select an option from each dropdown list and
+            click the green Go button. You can also start typing in any
+            dropdown box to filter the options you'll see. You can mix and
+            match between the lists to get answers to many different questions.
+            New: try typing any location, not just a state, into the location
+            box! Hovering over each area will show you its data.
             <br><br>
             The data you see comes from several sources within the census.
             Depending on your question, we choose the census data with the most
             information available. Most of our data come from the annual
             American Community Survey; if you ask about a year ending
-            in 0, you'll get information from the larger Decennial Survey instead.
+            in 0, you'll get information from the larger Decennial Survey 
+            instead. Both surveys provide estimates based on a sample
+            population; if you don't see any data for a county, it's because
+            the sample size was too small for an accurate estimate.
           </p>
         </div>
         <div class="tooltip">

--- a/src/main/webapp/query-control.js
+++ b/src/main/webapp/query-control.js
@@ -67,6 +67,9 @@ async function passQuery() {
       };
   } else { // Have to manually find which state the location is in
     locationInfo = await findStateOfLocation(locationInput);
+    if (locationInfo === undefined) {
+      return; // error was thrown inside findStateOfLocation()
+    }
     locationInput = locationInfo.name;
     location = locationInfo.number;
   }

--- a/src/main/webapp/query-control.js
+++ b/src/main/webapp/query-control.js
@@ -53,7 +53,7 @@ async function passQuery() {
   let locationInput = query.get('location');
   const locationSelector = document.querySelector('#location option[value=\'' + locationInput + '\']');
   let location;
-  let locationInfol
+  let locationInfo;
   if (locationSelector !== null) { // User picked a location from the dropdown
     location = locationSelector.dataset.value;
     locationInfo = {name: locationInput,

--- a/src/main/webapp/query-control.js
+++ b/src/main/webapp/query-control.js
@@ -52,7 +52,8 @@ async function passQuery() {
 
   let locationInput = query.get('location');
   const locationSelector =
-      document.querySelector('#location option[value=\'' + locationInput + '\']');
+      document.querySelector(
+          '#location option[value=\'' + locationInput + '\']');
   let location;
   let locationInfo;
   if (locationSelector !== null) { // User picked a location from the dropdown

--- a/src/main/webapp/query-control.js
+++ b/src/main/webapp/query-control.js
@@ -51,17 +51,19 @@ async function passQuery() {
     '#action option[value=\'' + actionInput + '\']').dataset.value;
 
   let locationInput = query.get('location');
-  const locationSelector = document.querySelector('#location option[value=\'' + locationInput + '\']');
+  const locationSelector =
+      document.querySelector('#location option[value=\'' + locationInput + '\']');
   let location;
   let locationInfo;
   if (locationSelector !== null) { // User picked a location from the dropdown
     location = locationSelector.dataset.value;
     locationInfo = {name: locationInput,
-      // either the center of the state, or the (slightly shifted for UX) center of the US
+      // Either the center of the state,
+      // or the (slightly shifted for UX) center of the US
       lat: location in stateInfo ? stateInfo[location].lat : 38.75,
       lng: location in stateInfo ? stateInfo[location].lng : -96.5,
-      number: location
-      }
+      number: location,
+      };
   } else { // Have to manually find which state the location is in
     locationInfo = await findStateOfLocation(locationInput);
     locationInput = locationInfo.name;
@@ -76,7 +78,8 @@ async function passQuery() {
       ).set(
         'moved', 'New inhabitants',
       );
-  const description = `${actionToPerson.get(action)} (${personType.replace('-', ' ')})`;
+  const description =
+      `${actionToPerson.get(action)} (${personType.replace('-', ' ')})`;
 
   const isCountyQuery = location !== 'state';
   const region = isCountyQuery ? locationInput + ' county' : 'U.S. state';

--- a/src/main/webapp/user-location.js
+++ b/src/main/webapp/user-location.js
@@ -6,7 +6,7 @@ const geoCodingUrl = 'https://maps.googleapis.com/maps/api/geocode/json?latlng='
 const geoLocationUrl = 'https://www.googleapis.com/geolocation/v1/geolocate?key=';
 const placesUrl =
     'https://maps.googleapis.com/maps/api/place/findplacefromtext/json?key=';
-const cors_api_url = 'https://cors-anywhere.herokuapp.com/';
+const corsApiUrl = 'https://cors-anywhere.herokuapp.com/';
 
 // Given the user's lat and lng from the geoLocation API,
 // getUserState calls to the geoCoding API to reverse geoCode
@@ -65,4 +65,38 @@ async function getDefaultValue() {
   const lng = location.lng;
   const state = await getUserState(lat, lng);
   return state;
+}
+
+// Given a text location (e.g New York City), use the Places API and geoCoding API to
+// find out what state the location is in
+async function findStateOfLocation(location) {
+  const fetchUrl =
+      corsApiUrl + placesUrl + apiKey 
+      + '&input=' + location + '&inputtype=textquery&fields=geometry';
+  const response = await fetch(fetchUrl);
+  const geoInfo = await response.json();
+  /*if (!response.ok) { //TODO: would like to use this
+    displayError(
+        response.status,
+        'There was an error trying to find the location you entered.');
+    return;
+  }*/
+  const place = geoInfo.candidates[0];
+  // TODO: change name of getUserState function
+  return getUserState(place.geometry.location.lat, place.geometry.location.lng)
+    .then(state => {
+      if (state === 'each U.S. state') { // TODO: change what gUS() returns when it fails
+        displayError(
+            400, 
+            'This location is not in one of the 50 U.S. states, or we are not able to find it.');
+        return;
+      }
+      else {
+        return {name: state,
+            lat: place.geometry.location.lat,
+            lng: place.geometry.location.lng,
+            number: document
+                .querySelector('#location option[value=\'' + state + '\']').dataset.value};
+      }
+    });
 }

--- a/src/main/webapp/user-location.js
+++ b/src/main/webapp/user-location.js
@@ -67,7 +67,7 @@ async function getDefaultValue() {
   return state;
 }
 
-// Given a text location (e.g New York City), use the Places API and geoCoding API to
+// Given a text location (e.g 'New York City'), use the Places API and geoCoding API to
 // find out what state the location is in
 async function findStateOfLocation(location) {
   const fetchUrl =
@@ -77,19 +77,20 @@ async function findStateOfLocation(location) {
   if (!response.ok) {
     displayError(
         response.status,
-        'There was an error trying to find the location you entered.');
+        'There was an error while trying to find the location you entered.');
     return;
   }
   const geoInfo = await response.json();
   const place = geoInfo.candidates[0];
-  // TODO: change name of getUserState function
+  // TODO: change name of getUserState function to be more generic
   return getUserState(place.geometry.location.lat, place.geometry.location.lng)
     .then(state => {
-      if (state === 'each U.S. state') { // TODO: change what gUS() returns when it fails
+      if (state === 'each U.S. state') { // TODO: have gUS() throw an error in this case
         displayError(
             400, 
-            'This location is not in one of the 50 U.S. states, or we are not able to \
-            find it (try being more specific or adding the state code).');
+            'Either this location is not in one of the 50 U.S. states, or we \
+            are not able to find it (try being more specific or adding the \
+            state code).');
         return;
       }
       else {

--- a/src/main/webapp/user-location.js
+++ b/src/main/webapp/user-location.js
@@ -6,6 +6,7 @@ const geoCodingUrl = 'https://maps.googleapis.com/maps/api/geocode/json?latlng='
 const geoLocationUrl = 'https://www.googleapis.com/geolocation/v1/geolocate?key=';
 const placesUrl =
     'https://maps.googleapis.com/maps/api/place/findplacefromtext/json?key=';
+const cors_api_url = 'https://cors-anywhere.herokuapp.com/';
 
 // Given the user's lat and lng from the geoLocation API,
 // getUserState calls to the geoCoding API to reverse geoCode

--- a/src/main/webapp/user-location.js
+++ b/src/main/webapp/user-location.js
@@ -74,13 +74,13 @@ async function findStateOfLocation(location) {
       corsApiUrl + placesUrl + apiKey 
       + '&input=' + location + '&inputtype=textquery&fields=geometry';
   const response = await fetch(fetchUrl);
-  const geoInfo = await response.json();
-  /*if (!response.ok) { //TODO: would like to use this
+  if (!response.ok) {
     displayError(
         response.status,
         'There was an error trying to find the location you entered.');
     return;
-  }*/
+  }
+  const geoInfo = await response.json();
   const place = geoInfo.candidates[0];
   // TODO: change name of getUserState function
   return getUserState(place.geometry.location.lat, place.geometry.location.lng)
@@ -88,7 +88,8 @@ async function findStateOfLocation(location) {
       if (state === 'each U.S. state') { // TODO: change what gUS() returns when it fails
         displayError(
             400, 
-            'This location is not in one of the 50 U.S. states, or we are not able to find it.');
+            'This location is not in one of the 50 U.S. states, or we are not able to \
+            find it (try being more specific or adding the state code).');
         return;
       }
       else {

--- a/src/main/webapp/user-location.js
+++ b/src/main/webapp/user-location.js
@@ -4,6 +4,8 @@ const fetchJson = {
 };
 const geoCodingUrl = 'https://maps.googleapis.com/maps/api/geocode/json?latlng=';
 const geoLocationUrl = 'https://www.googleapis.com/geolocation/v1/geolocate?key=';
+const placesUrl =
+    'https://maps.googleapis.com/maps/api/place/findplacefromtext/json?key=';
 
 // Given the user's lat and lng from the geoLocation API,
 // getUserState calls to the geoCoding API to reverse geoCode

--- a/src/main/webapp/user-location.js
+++ b/src/main/webapp/user-location.js
@@ -101,7 +101,7 @@ async function findStateOfLocation(location) {
   // TODO: change name of getUserState function to be more generic
   return getUserState(place.geometry.location.lat, place.geometry.location.lng)
     .then((state) => {
-      if (state === 'each U.S. state') { 
+      if (state === 'each U.S. state') {
         // TODO: have gUS() throw an error in this case instead
         displayError(
             400,
@@ -115,7 +115,7 @@ async function findStateOfLocation(location) {
             lng: place.geometry.location.lng,
             number: document
                 .querySelector(
-                    '#location option[value=\'' + 
+                    '#location option[value=\'' +
                     state + '\']').dataset.value};
       }
     });

--- a/src/main/webapp/user-location.js
+++ b/src/main/webapp/user-location.js
@@ -83,12 +83,12 @@ async function getUserState() {
   }
 }
 
-// Given a text location (e.g 'New York City'), use the Places API and geoCoding API to
-// find out what state the location is in
+// Given a text location (e.g 'New York City'), use the Places API and
+// geoCoding API to find out what state the location is in
 async function findStateOfLocation(location) {
   const fetchUrl =
-      corsApiUrl + placesUrl + apiKey 
-      + '&input=' + location + '&inputtype=textquery&fields=geometry';
+      corsApiUrl + placesUrl + apiKey +
+      '&input=' + location + '&inputtype=textquery&fields=geometry';
   const response = await fetch(fetchUrl);
   if (!response.ok) {
     displayError(
@@ -100,21 +100,23 @@ async function findStateOfLocation(location) {
   const place = geoInfo.candidates[0];
   // TODO: change name of getUserState function to be more generic
   return getUserState(place.geometry.location.lat, place.geometry.location.lng)
-    .then(state => {
-      if (state === 'each U.S. state') { // TODO: have gUS() throw an error in this case
+    .then((state) => {
+      if (state === 'each U.S. state') { 
+        // TODO: have gUS() throw an error in this case instead
         displayError(
-            400, 
+            400,
             'Either this location is not in one of the 50 U.S. states, or we \
             are not able to find it (try being more specific or adding the \
             state code).');
         return;
-      }
-      else {
+      } else {
         return {name: state,
             lat: place.geometry.location.lat,
             lng: place.geometry.location.lng,
             number: document
-                .querySelector('#location option[value=\'' + state + '\']').dataset.value};
+                .querySelector(
+                    '#location option[value=\'' + 
+                    state + '\']').dataset.value};
       }
     });
 }


### PR DESCRIPTION
Users can now type any location into the state dropdown (including cities, counties, store names, and zip codes - anything that could be successfully typed into Google Maps). When they do, they will see the visualization for the state containing their location, centered on the location itself.

I haven't yet thought of a good way to show the user that they can type anything they want into the location field (other than adding it to the FAQ); maybe we could style it a little differently? Would be interested in your thoughts here.