### PR TITLE
Don't require commenting/uncommenting

### DIFF
--- a/src/main/java/ObjectifyInit.java
+++ b/src/main/java/ObjectifyInit.java
@@ -7,17 +7,7 @@ import javax.servlet.ServletContextListener;
 
 public class ObjectifyInit implements ServletContextListener {
   public void contextInitialized(ServletContextEvent event) {
-    ObjectifyService.init(
-        new ObjectifyFactory(
-            DatastoreOptions.newBuilder()
-                // This host is used for testing using a datastore emulator
-                .setHost("http://localhost:8484")
-                .setProjectId("censusviz")
-                .build()
-                .getService()));
-    // To deploy, everything above this must be commented out
-    // and line directly below show be uncommented
-    // ObjectifyService.init();
+    ObjectifyService.init();
     ObjectifyService.register(CensusData.class);
   }
 

--- a/src/main/java/ObjectifyInit.java
+++ b/src/main/java/ObjectifyInit.java
@@ -1,6 +1,4 @@
-import com.google.cloud.datastore.DatastoreOptions;
 import com.google.sps.data.CensusData;
-import com.googlecode.objectify.ObjectifyFactory;
 import com.googlecode.objectify.ObjectifyService;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;


### PR DESCRIPTION
We'll no longer have to comment/uncomment to deploy. We just need to have three env variables set:
```console
export DATASTORE_PROJECT_ID=censusviz
export DATASTORE_USE_PROJECT_ID_AS_APP_ID=true
export DATASTORE_EMULATOR_HOST=localhost:8484
```
We can add these to ~/.bashrc so they're always set