### PR TITLE
Remove data for Puerto Rico

### DIFF
--- a/src/main/webapp/query-control.js
+++ b/src/main/webapp/query-control.js
@@ -147,7 +147,7 @@ function removeErroneousData(dataArray) {
   dataArray.forEach((elem, index) => {
     // Using splice, directly modifies array
     elem.forEach((item) => {
-      if (item === null || item < 0) {
+      if (item === null || item < 0 || item === 'Puerto Rico') {
         dataArray.splice(index, 1);
       }
     });


### PR DESCRIPTION
I guess the Census API must have changed Puerto Rico from being null to 0, so I remove any rows for Puerto Rico now