### PR TITLE
Add button to edit title

### DIFF
--- a/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/src/main/webapp/WEB-INF/appengine-web.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+  <application>censusviz</application>
   <threadsafe>false</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <runtime>java8</runtime>

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -91,26 +91,26 @@ function displayAmChartsMap(
         {
           'label': 'Image',
           'menu': [
-            {'type': 'png', 'label': 'PNG' },
-            {'type': 'jpg', 'label': 'JPG' },
-            {'type': 'svg', 'label': 'SVG' },
-            {'type': 'pdf', 'label': 'PDF' },
+            {'type': 'png', 'label': 'PNG'},
+            {'type': 'jpg', 'label': 'JPG'},
+            {'type': 'svg', 'label': 'SVG'},
+            {'type': 'pdf', 'label': 'PDF'},
           ],
         }, {
           'label': 'Data',
           'menu': [
-            {'type': 'json', 'label': 'JSON' },
-            {'type': 'csv', 'label': 'CSV' },
-            {'type': 'xlsx', 'label': 'XLSX' },
-            {'type': 'html', 'label': 'HTML' },
-            {'type': 'pdfdata', 'label': 'PDF' },
+            {'type': 'json', 'label': 'JSON'},
+            {'type': 'csv', 'label': 'CSV'},
+            {'type': 'xlsx', 'label': 'XLSX'},
+            {'type': 'html', 'label': 'HTML'},
+            {'type': 'pdfdata', 'label': 'PDF'},
           ],
         }, {
-          'label': 'Print', 'type': 'print'
-        }
-      ]
-    }
-  ]
+          'label': 'Print', 'type': 'print',
+        },
+      ],
+    },
+  ];
 
   const isCountyQuery = data[0].id.indexOf('US') === -1;
   // Albers projection for state level, Mercator for county level

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -87,6 +87,18 @@ function displayAmChartsMap(
   chart.exporting.menu.align = 'left';
   chart.exporting.menu.verticalAlign = 'top';
   chart.exporting.filePrefix = title;
+  chart.exporting.adapter.add('data', function(data) {
+    data.data = [];
+    for (let i = 0; i < polygonSeries.data.length; i++) {
+      const row = polygonSeries.data[i];
+      data.data.push({
+        id: row.id,
+        name: row.name,
+        value: row.value
+      });
+    }
+    return data;
+  });  
   chart.exporting.menu.items = [
     {
       'label': 'Download',

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -83,7 +83,7 @@ function displayAmChartsMap(
   chart.exporting.menu = new am4core.ExportMenu();
   chart.exporting.menu.align = 'left';
   chart.exporting.menu.verticalAlign = 'top';
-  chart.exporting.filePrefix = 'CensusViz';
+  chart.exporting.filePrefix = title;
   chart.exporting.menu.items = [
     {
       'label': 'Download',

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -27,6 +27,7 @@ async function getGeoData(locationInfo, isCountyQuery) {
 async function displayVisualization(censusDataArray, description, title,
   locationInfo, isCountyQuery) {
   document.getElementById('colors').style.display = 'block';
+  document.getElementById('open-edit-title').style.display = 'inline';
   const color = getColor();
   const geoData = await getGeoData(locationInfo, isCountyQuery);
   // Put all necessary data in the cache
@@ -110,7 +111,7 @@ function displayAmChartsMap(
       ]
     }
   ]
-  
+
   const isCountyQuery = data[0].id.indexOf('US') === -1;
   // Albers projection for state level, Mercator for county level
   if (isCountyQuery) {

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -83,7 +83,34 @@ function displayAmChartsMap(
   chart.exporting.menu.align = 'left';
   chart.exporting.menu.verticalAlign = 'top';
   chart.exporting.filePrefix = 'CensusViz';
-
+  chart.exporting.menu.items = [
+    {
+      "label": "Download",
+      "menu": [
+        {
+          "label": "Image",
+          "menu": [
+            { "type": "png", "label": "PNG" },
+            { "type": "jpg", "label": "JPG" },
+            { "type": "svg", "label": "SVG" },
+            { "type": "pdf", "label": "PDF" }
+          ]
+        }, {
+          "label": "Data",
+          "menu": [
+            { "type": "json", "label": "JSON" },
+            { "type": "csv", "label": "CSV" },
+            { "type": "xlsx", "label": "XLSX" },
+            { "type": "html", "label": "HTML" },
+            { "type": "pdfdata", "label": "PDF" }
+          ]
+        }, {
+          "label": "Print", "type": "print"
+        }
+      ]
+    }
+  ]
+  
   const isCountyQuery = data[0].id.indexOf('US') === -1;
   // Albers projection for state level, Mercator for county level
   if (isCountyQuery) {

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -94,11 +94,11 @@ function displayAmChartsMap(
       data.data.push({
         id: row.id,
         name: row.name,
-        value: row.value
+        value: row.value,
       });
     }
     return data;
-  });  
+  });
   chart.exporting.menu.items = [
     {
       'label': 'Download',

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -86,27 +86,27 @@ function displayAmChartsMap(
   chart.exporting.filePrefix = 'CensusViz';
   chart.exporting.menu.items = [
     {
-      "label": "Download",
-      "menu": [
+      'label': 'Download',
+      'menu': [
         {
-          "label": "Image",
-          "menu": [
-            { "type": "png", "label": "PNG" },
-            { "type": "jpg", "label": "JPG" },
-            { "type": "svg", "label": "SVG" },
-            { "type": "pdf", "label": "PDF" }
-          ]
+          'label': 'Image',
+          'menu': [
+            {'type': 'png', 'label': 'PNG' },
+            {'type': 'jpg', 'label': 'JPG' },
+            {'type': 'svg', 'label': 'SVG' },
+            {'type': 'pdf', 'label': 'PDF' },
+          ],
         }, {
-          "label": "Data",
-          "menu": [
-            { "type": "json", "label": "JSON" },
-            { "type": "csv", "label": "CSV" },
-            { "type": "xlsx", "label": "XLSX" },
-            { "type": "html", "label": "HTML" },
-            { "type": "pdfdata", "label": "PDF" }
-          ]
+          'label': 'Data',
+          'menu': [
+            {'type': 'json', 'label': 'JSON' },
+            {'type': 'csv', 'label': 'CSV' },
+            {'type': 'xlsx', 'label': 'XLSX' },
+            {'type': 'html', 'label': 'HTML' },
+            {'type': 'pdfdata', 'label': 'PDF' },
+          ],
         }, {
-          "label": "Print", "type": "print"
+          'label': 'Print', 'type': 'print'
         }
       ]
     }

--- a/src/main/webapp/data-visualization.js
+++ b/src/main/webapp/data-visualization.js
@@ -397,10 +397,13 @@ async function displayCountyGeoJson(mapsData, description,
 function toggleMap() {
   const checkbox = document.getElementById('map-toggle');
   if (checkbox.checked) {
+    document.getElementById('open-edit-title').style.display = 'none';
+    document.getElementById('edit-title').style.display = 'none';
     document.getElementById('am-charts').style.display = 'none';
     document.getElementById('map').style.display = 'block';
     document.getElementById('map-toggle-msg').innerText = 'Disable map overlay';
   } else {
+    document.getElementById('open-edit-title').style.display = 'inline';
     document.getElementById('map').style.display = 'none';
     document.getElementById('am-charts').style.display = 'block';
     document.getElementById('map-toggle-msg').innerText = 'Enable map overlay';

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -44,8 +44,8 @@
             The data you see comes from several sources within the census.
             Depending on your question, we choose the census data with the most
             information available. Most of our data come from the annual
-            American Community Survey; if you ask about a year ending
-            in 0, you'll get information from the larger Decennial Survey
+            American Community Survey; if you ask about 2010, you'll get
+            information from the larger Decennial Survey
             instead. Both surveys provide estimates based on a sample
             population; if you don't see any data for a county, it's because
             the sample size was too small for an accurate estimate.
@@ -123,10 +123,10 @@
           </input>
           in
           <input type="list" list="year" name="year" id="year-list" autocomplete="off" required
-            onkeyup="validateInput('year')" onfocus="storeValueAndEmpty('year')"
-            onfocusout="replaceValueIfEmpty('year')" value="2018" pattern="201[0-8]">
+            onkeyup="validateInput('year')" onfocus="storeValueAndEmpty('year')" value="2018"
+            onfocusout="replaceValueIfEmpty('year')" pattern="2010 \(decennial census\)|201[0-8]">
           <datalist id="year">
-            <option data-value="2010" value="2010"></option>
+            <option data-value="2010" value="2010 (decennial census)"></option>
             <option data-value="2011" value="2011"></option>
             <option data-value="2012" value="2012"></option>
             <option data-value="2013" value="2013"></option>

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -160,7 +160,11 @@
           </label>
         </p>
       </div>
-      <br>
+      <button id="open-edit-title" onclick="showEditTitle()">Edit title</button>
+      <form id="edit-title" onsubmit="editTitle();return false;">
+        <input type="text" id="edit-title-text">
+        <input type="submit" value="done">
+      </form>
       <div id="am-charts"></div>
       <div id="map"></div>
       <button id="toggle-data-btn" onclick="toggleDataTable()">Display raw data</button>

--- a/src/main/webapp/query-control.js
+++ b/src/main/webapp/query-control.js
@@ -206,6 +206,8 @@ async function passQuery(personType, action, location, year, title) {
   if (title === '') { // no user-chosen title available
       title = getTitle(personType, location, year, state, actionInput);
   }
+  localStorage.setItem('title', title);
+
   const fetchUrl = getFetchUrl('query', personType, action, location, year);
   fetch(fetchUrl)
     .then((response) => response.json().then((jsonResponse) => ({
@@ -299,6 +301,10 @@ function replaceValueIfEmpty(dataListId) {
 // Show the div that allows for AmCharts map title editing
 function showEditTitle() {
   document.getElementById('edit-title').style.display = 'inline';
+  const currentTitle = localStorage.getItem('title');
+  if (currentTitle !== undefined) {
+    document.getElementById('edit-title-text').value = currentTitle;
+  }
 }
 
 // Update the title in the AmCharts map

--- a/src/main/webapp/query-control.js
+++ b/src/main/webapp/query-control.js
@@ -26,6 +26,7 @@ function getColor() {
 function clearPreviousResult() {
   document.getElementById('data-table').innerHTML = '';
   document.getElementById('colors').style.display = 'none';
+  document.getElementById('edit-title').style.display = 'none';
   document.getElementById('census-link').style.display = 'none';
   document.getElementById('toggle-data-btn').style.display = 'none';
   document.getElementById('map-options').style.display = 'none';
@@ -161,7 +162,7 @@ function submitQuery() {
 // Breaks down the query and passes it to the backend to be analyzed;
 // the backend returns the appropriate data, which is then passed off
 // to be reformatted and visualized.
-async function passQuery(personType, action, location, year) {
+async function passQuery(personType, action, location, year, title) {
   clearPreviousResult();
   const locationDropdown = document.querySelector(
     '#location option[data-value=\'' + location + '\']');
@@ -201,7 +202,9 @@ async function passQuery(personType, action, location, year) {
       `${actionToPerson.get(action)} (${personType.replace('-', ' ')})`;
 
   const isCountyQuery = location !== 'state';
-  const title = getTitle(personType, location, year, state, actionInput);
+  if (title === '') { // no user-chosen title available
+      title = getTitle(personType, location, year, state, actionInput);
+  }
   const fetchUrl = getFetchUrl('query', personType, action, location, year);
   fetch(fetchUrl)
     .then((response) => response.json().then((jsonResponse) => ({
@@ -290,6 +293,16 @@ function replaceValueIfEmpty(dataListId) {
   if (typedSoFar === '') {
     inputlist.value = storedVal;
   }
+}
+
+function showEditTitle() {
+  document.getElementById('edit-title').style.display = 'inline';
+}
+
+function editTitle() {
+  const title = document.getElementById('edit-title-text').value;
+  submitHashQuery(title);
+  return false;
 }
 
 // Return an array of state number and name sorted alphabetically.
@@ -417,7 +430,7 @@ function setDropdownValue(datalistId, value) {
 
 // Called on load and on hash change. Check for
 // query params in url and call passQuery() if found.
-function submitHashQuery() {
+function submitHashQuery(title='') {
   const urlHash = window.location.hash;
   if (urlHash) {
     const params = new URLSearchParams(urlHash.slice(1));
@@ -428,7 +441,7 @@ function submitHashQuery() {
     const action = params.get('action');
     const location = params.get('location');
     const year = params.get('year');
-    passQuery(personType, action, location, year);
+    passQuery(personType, action, location, year, title);
   }
 }
 

--- a/src/main/webapp/query-control.js
+++ b/src/main/webapp/query-control.js
@@ -81,7 +81,7 @@ function getHistory() {
   const historyContainer = document.getElementById('history');
   historyContainer.innerHTML = '';
   const header = document.createElement('p');
-  header.innerText = 'Pages you've Viewed';
+  header.innerText = 'Pages you\'ve Viewed';
   historyContainer.appendChild(header);
   const fetchUrl = '/history?user-id=' + getUserId();
   fetch(fetchUrl).then(function(response) {

--- a/src/main/webapp/query-control.js
+++ b/src/main/webapp/query-control.js
@@ -81,7 +81,7 @@ function getHistory() {
   const historyContainer = document.getElementById('history');
   historyContainer.innerHTML = '';
   const header = document.createElement('p');
-  header.innerText = "Pages you've Viewed";
+  header.innerText = 'Pages you've Viewed';
   historyContainer.appendChild(header);
   const fetchUrl = '/history?user-id=' + getUserId();
   fetch(fetchUrl).then(function(response) {

--- a/src/main/webapp/query-control.js
+++ b/src/main/webapp/query-control.js
@@ -137,11 +137,14 @@ function submitQuery() {
   const personTypeInput = query.get('person-type');
   const actionInput = query.get('action');
   const locationInput = query.get('location').replace(/'/g, '');
-  const year = query.get('year');
+  const yearInput = query.get('year');
+
   const personType = document.querySelector(
     '#person-type option[value=\'' + personTypeInput + '\']').dataset.value;
   const action = document.querySelector(
     '#action option[value=\'' + actionInput + '\']').dataset.value;
+  const year = document.querySelector(
+    '#year option[value=\'' + yearInput + '\']').dataset.value;
   const locationDropdown = document.querySelector(
     '#location option[value=\'' + locationInput + '\']');
   let location;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -141,9 +141,9 @@ input[type=submit]:hover {
 
 /* Download/export button for amcharts */
 .amcharts-amexport-item-level-0 {
-  width: 100px!important;
-  height: 35px!important;
-  padding: 7px 0 0 0!important;
+  width: 100px !important;
+  height: 35px !important;
+  padding: 7px 0 0 0 !important;
 }
 
 #map {

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -131,6 +131,13 @@ input[type=submit]:hover {
   height: 650px;
 }
 
+/* Download/export button for amcharts */
+.amcharts-amexport-item-level-0 {
+  width: 100px!important;
+  height: 35px!important;
+  padding: 7px 0 0 0!important;
+}
+
 #map {
   height: 700px;
   display: none;

--- a/src/main/webapp/style.css
+++ b/src/main/webapp/style.css
@@ -127,6 +127,14 @@ input[type=submit]:hover {
   text-align: center;
 }
 
+#open-edit-title {
+  display: none;
+}
+
+#edit-title {
+  display: none;
+}
+
 #am-charts {
   height: 650px;
 }
@@ -219,12 +227,6 @@ input:checked + .slider::before {
   padding: 5px;
   text-transform: uppercase;
   font-weight: bolder;
-}
-
-#map-title {
-  text-align: center;
-  font-weight: bolder;
-  font-size: 20px;
 }
 
 #more-info {


### PR DESCRIPTION
https://censusviz.appspot.com/
Allow the user to edit the title of the amcharts map.

The title they choose will be saved when they download the image, but not on page reload. The user can "get back" our default title by reloading the page, asking the query again, or simply entering a blank title into the box.

Notes:
-I mostly didn't add a lot of formatting to these buttons because we are discussing doing a sitewide redesign of our buttons right now anyway.
-This PR also includes an update to the year dropdown to label 2010 as a special year, and an update to the amcharts export button so it says Download explicitly. Both are very small changes.